### PR TITLE
fix: 即時クラッシュバグ 0-1〜0-6 を修正

### DIFF
--- a/neteye/api/cable_namespace.py
+++ b/neteye/api/cable_namespace.py
@@ -21,10 +21,10 @@ api.add_namespace(cables_api)
 
 cable_model = cables_api.model('Cable', {
     'id': fields.String(description='The UUID of the cable'),
-    'src_node_id': fields.String(description='The source node ID'),
-    'src_interface_id': fields.String(description='The source interface ID'),
-    'dst_node_id': fields.String(description='The destination node ID'),
-    'dst_interface_id': fields.String(description='The destination interface ID'),
+    'a_interface_id': fields.String(description='The A-side interface ID'),
+    'b_interface_id': fields.String(description='The B-side interface ID'),
+    'cable_type': fields.String(description='The type of the cable'),
+    'link_speed': fields.String(description='The link speed'),
     'description': fields.String(description='The description of the cable')
 })
 

--- a/neteye/arp_entry/models.py
+++ b/neteye/arp_entry/models.py
@@ -37,6 +37,7 @@ class ArpEntry(Base):
             id=self.id, ip_address=self.ip_address, mac_address=self.mac_address
         )
 
+    @staticmethod
     def exists(ip_address, interface_id):
         return ArpEntry.query.filter_by(ip_address=ip_address, interface_id=interface_id).scalar() != None
 

--- a/neteye/base/routes.py
+++ b/neteye/base/routes.py
@@ -1,20 +1,24 @@
 from neteye.blueprints import bp_factory
 from flask import request, redirect, url_for, render_template, flash, session
+from flask_security import auth_required
 
 
 base_bp = bp_factory("base")
 
 
 @base_bp.route("/")
+@auth_required()
 def index():
     return render_template("index.html")
 
 
 @base_bp.route("/<path>")
+@auth_required()
 def template(path):
     return render_template(path)
 
 
 @base_bp.route("/<directory>/<path>")
+@auth_required()
 def subdir_template(directory, path):
     return render_template(directory + "/" + path)

--- a/neteye/cable/routes.py
+++ b/neteye/cable/routes.py
@@ -1,7 +1,7 @@
 from logging import getLogger
 
 import pandas as pd
-from flask import flash, jsonify, redirect, render_template, request, session, url_for
+from flask import abort, flash, jsonify, redirect, render_template, request, session, url_for
 from flask_security import auth_required, current_user
 from sqlalchemy.orm import aliased
 from sqlalchemy.exc import IntegrityError
@@ -120,6 +120,8 @@ def create():
 @auth_required()
 def edit(id):
     cable = Cable.get(id)
+    if not cable:
+        abort(404)
     form = CableForm()
     a_interface = cable.a_interface
     b_interface = cable.b_interface
@@ -145,6 +147,8 @@ def edit(id):
 def update(id):
     sorted_interface_ids = "-".join(sorted([request.form["a_interface"], request.form["b_interface"]]))
     cable = Cable.get(id)
+    if not cable:
+        abort(404)
     cable.a_interface_id = request.form["a_interface"]
     cable.b_interface_id = request.form["b_interface"]
     cable.cable_type = request.form["cable_type"]
@@ -169,5 +173,7 @@ def update(id):
 @auth_required()
 def delete(id):
     cable = Cable.get(id)
+    if not cable:
+        abort(404)
     cable.delete()
     return redirect(url_for("cable.index"))

--- a/neteye/history/routes.py
+++ b/neteye/history/routes.py
@@ -73,10 +73,11 @@ def node_history_data():
                              node_version.operation_type).join(node_version, node_version.transaction_id == node_transaction.id)
     params = request.args.to_dict()
     row_table = DataTables(params, query, columns)
-    for row in row_table.output_result()["data"]:
+    result = row_table.output_result()
+    for row in result["data"]:
         row['0'] = row['0'].replace(tzinfo=datetime.timezone.utc).astimezone(tz.tzlocal()).strftime('%Y-%m-%d %H:%M:%S.%f %Z')
         row['10'] = OPERATION_TYPE[row['10']]
-    return jsonify(row_table.output_result())
+    return jsonify(result)
 
 
 @history_bp.route("/interface_history")
@@ -104,10 +105,11 @@ def interface_history_data():
                              interface_version.operation_type).join(interface_version, interface_version.transaction_id == interface_transaction.id)
     params = request.args.to_dict()
     row_table = DataTables(params, query, columns)
-    for row in row_table.output_result()["data"]:
+    result = row_table.output_result()
+    for row in result["data"]:
         row['0'] = row['0'].replace(tzinfo=datetime.timezone.utc).astimezone(tz.tzlocal()).strftime('%Y-%m-%d %H:%M:%S.%f %Z')
         row['6'] = OPERATION_TYPE[row['6']]
-    return jsonify(row_table.output_result())
+    return jsonify(result)
 
 
 @history_bp.route("/serial_history")
@@ -132,10 +134,11 @@ def serial_history_data():
                              serial_version.operation_type).join(serial_version, serial_version.transaction_id == serial_transaction.id)
     params = request.args.to_dict()
     row_table = DataTables(params, query, columns)
-    for row in row_table.output_result()["data"]:
+    result = row_table.output_result()
+    for row in result["data"]:
         row['0'] = row['0'].replace(tzinfo=datetime.timezone.utc).astimezone(tz.tzlocal()).strftime('%Y-%m-%d %H:%M:%S.%f %Z')
         row['5'] = OPERATION_TYPE[row['5']]
-    return jsonify(row_table.output_result())
+    return jsonify(result)
 
 
 
@@ -149,8 +152,8 @@ def cable_history_data():
     columns = [
         ColumnDT(cable_transaction.issued_at),
         ColumnDT(cable_version.id),
-        ColumnDT(cable_version.src_interface_id),
-        ColumnDT(cable_version.dst_interface_id),
+        ColumnDT(cable_version.a_interface_id),
+        ColumnDT(cable_version.b_interface_id),
         ColumnDT(cable_version.description),
         ColumnDT(cable_version.cable_type),
         ColumnDT(cable_version.link_speed),
@@ -158,18 +161,19 @@ def cable_history_data():
     ]
     query = db.session.query(cable_transaction.issued_at,
                              cable_version.id,
-                             cable_version.src_interface_id,
-                             cable_version.dst_interface_id,
+                             cable_version.a_interface_id,
+                             cable_version.b_interface_id,
                              cable_version.description,
                              cable_version.cable_type,
                              cable_version.link_speed,
                              cable_version.operation_type).join(cable_version, cable_version.transaction_id == cable_transaction.id)
     params = request.args.to_dict()
     row_table = DataTables(params, query, columns)
-    for row in row_table.output_result()["data"]:
+    result = row_table.output_result()
+    for row in result["data"]:
         row['0'] = row['0'].replace(tzinfo=datetime.timezone.utc).astimezone(tz.tzlocal()).strftime('%Y-%m-%d %H:%M:%S.%f %Z')
         row['7'] = OPERATION_TYPE[row['7']]
-    return jsonify(row_table.output_result())
+    return jsonify(result)
 
 
 @history_bp.route("/arp_entry_history")
@@ -201,10 +205,11 @@ def arp_entry_history_data():
                              arp_entry_version.operation_type).join(arp_entry_version, arp_entry_version.transaction_id == arp_entry_transaction.id)
     params = request.args.to_dict()
     row_table = DataTables(params, query, columns)
-    for row in row_table.output_result()["data"]:
+    result = row_table.output_result()
+    for row in result["data"]:
         row['0'] = row['0'].replace(tzinfo=datetime.timezone.utc).astimezone(tz.tzlocal()).strftime('%Y-%m-%d %H:%M:%S.%f %Z')
         row['8'] = OPERATION_TYPE[row['8']]
-    return jsonify(row_table.output_result())
+    return jsonify(result)
 
 @history_bp.route("/command_history")
 def command_history():
@@ -224,9 +229,10 @@ def command_history_data():
     query = db.session.query().select_from(CommandHistory)
     params = request.args.to_dict()
     row_table = DataTables(params, query, columns)
-    for row in row_table.output_result()["data"]:
+    result = row_table.output_result()
+    for row in result["data"]:
         row['0'] = row['0'].replace(tzinfo=datetime.timezone.utc).astimezone(tz.tzlocal()).strftime('%Y-%m-%d %H:%M:%S.%f %Z')
-    return jsonify(row_table.output_result())
+    return jsonify(result)
 
 @history_bp.route("/command_history/<id>/result")
 def command_history_result(id):

--- a/neteye/interface/models.py
+++ b/neteye/interface/models.py
@@ -30,6 +30,7 @@ class Interface(Base):
             id=self.id, node_id=self.node_id, name=self.name
         )
 
+    @staticmethod
     def exists(node_id, name):
         return (
             Interface.query.filter_by(node_id=node_id)

--- a/neteye/interface/routes.py
+++ b/neteye/interface/routes.py
@@ -50,6 +50,8 @@ def data():
 @auth_required()
 def show(id):
     interface = Interface.get(id)
+    if not interface:
+        abort(404)
     node = Node.get(interface.node_id)
     return render_template("interface/show.html", interface=interface, node=node)
 
@@ -121,6 +123,8 @@ def create():
 @auth_required()
 def edit(id):
     interface = Interface.get(id)
+    if not interface:
+        abort(404)
     form = InterfaceForm()
     node_id = interface.node_id
     name = interface.name
@@ -165,6 +169,8 @@ def update(id):
     status = request.form["status"]
     if form.validate_on_submit():
         interface = Interface.get(id)
+        if not interface:
+            abort(404)
         interface.node_id = node_id
         interface.name = name
         interface.description = description
@@ -209,6 +215,8 @@ def update(id):
 @auth_required()
 def delete(id):
     interface = Interface.get(id)
+    if not interface:
+        abort(404)
     interface.delete()
     return redirect(url_for("interface.index"))
 

--- a/neteye/serial/models.py
+++ b/neteye/serial/models.py
@@ -25,6 +25,7 @@ class Serial(Base):
             node_id=self.node_id,
         )
 
+    @staticmethod
     def exists(serial_number):
         return Serial.query.filter_by(serial_number=serial_number).scalar() != None
 

--- a/neteye/serial/routes.py
+++ b/neteye/serial/routes.py
@@ -41,6 +41,8 @@ def data():
 @auth_required()
 def show(id):
     serial = Serial.get(id)
+    if not serial:
+        abort(404)
     node = Node.get(serial.node_id)
     return render_template("serial/show.html", serial=serial, node=node)
 
@@ -69,6 +71,8 @@ def create():
 @auth_required()
 def edit(id):
     serial = Serial.get(id)
+    if not serial:
+        abort(404)
     form = SerialForm()
     node_id = serial.node_id
     serial_number = serial.serial_number
@@ -89,6 +93,8 @@ def edit(id):
 @auth_required()
 def update(id):
     serial = Serial.get(id)
+    if not serial:
+        abort(404)
     serial.node_id = request.form["node_id"]
     serial.serial_number = request.form["serial_number"]
     serial.product_id = request.form["product_id"]
@@ -102,6 +108,8 @@ def update(id):
 @auth_required()
 def delete(id):
     serial = Serial.get(id)
+    if not serial:
+        abort(404)
     serial.delete()
     return redirect(url_for("serial.index"))
 
@@ -123,7 +131,7 @@ def filter():
     else:
         serials = (
             Serial.query.join(Node, Serial.node_id == Node.id)
-            .add_columns(Serial.id, Node.hostname, Serial.serial, Serial.product_id)
+            .add_columns(Serial.id, Node.hostname, Serial.serial_number, Serial.product_id)
             .filter(Node.hostname.contains(filter_str))
         )
     return render_template("serial/index.html", serials=serials)

--- a/neteye/visualization/routes.py
+++ b/neteye/visualization/routes.py
@@ -28,11 +28,11 @@ intf_conv = IntfAbbrevConverter("cisco_ios")
 def layer1():
     cables = (
         Cable.query.join(
-            src_interface_table, Cable.src_interface_id == src_interface_table.id
+            src_interface_table, Cable.a_interface_id == src_interface_table.id
         )
         .add_columns(src_interface_table.name)
         .join(src_node_table, src_interface_table.node_id == src_node_table.id)
-        .join(dst_interface_table, Cable.dst_interface_id == dst_interface_table.id)
+        .join(dst_interface_table, Cable.b_interface_id == dst_interface_table.id)
         .join(dst_node_table, dst_interface_table.node_id == dst_node_table.id)
         .add_columns(
             Cable.id,


### PR DESCRIPTION
## Summary

- **0-1** `visualization/routes.py` の `Cable.src/dst_interface_id` を `a/b_interface_id` に修正（layer1 がクラッシュしていた）。`history/routes.py` の `cable_version`、`api/cable_namespace.py` の cable_model フィールド定義も同様に修正
- **0-2** `serial/routes.py` filter ルートの `Serial.serial` を `Serial.serial_number` に修正（`field=node` でクラッシュしていた）
- **0-3** `history/routes.py` の全6データルートで `output_result()` を1回だけ呼ぶよう修正（タイムスタンプ・operation_type 変換が消えていたバグ）
- **0-4** `Interface.exists()` / `Serial.exists()` / `ArpEntry.exists()` に `@staticmethod` を追加（引数シフトバグ）
- **0-5** `interface` / `cable` / `serial` の show・edit・update・delete ルートに `None` チェック + `abort(404)` を追加
- **0-6** `base/routes.py` の汎用テンプレートレンダリングルートに `@auth_required()` を追加

## Test plan

- [x] `pytest tests/ -x -q` — 38テスト全通過確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)