### PR TITLE
feat(auth): 1-E 認証・認可の網羅

### DIFF
--- a/neteye/api/arp_entry_namespace.py
+++ b/neteye/api/arp_entry_namespace.py
@@ -1,9 +1,10 @@
 from flask import jsonify, request
-from flask_restx import Namespace, Resource, ValidationError, fields, abort
+from flask_restx import Namespace, ValidationError, fields, abort
 
 from neteye.api.interface_namespace import InterfaceSchema
 from neteye.api.routes import api_bp
 from neteye.arp_entry.models import ArpEntry
+from neteye.api.routes import AuthenticatedResource
 from neteye.extensions import api, db, ma
 
 
@@ -28,7 +29,7 @@ arp_entry_model = arp_entries_api.model('ArpEntry', {
 })
 
 @arp_entries_api.route("", "/")
-class ArpEntrysResource(Resource):
+class ArpEntrysResource(AuthenticatedResource):
     @arp_entries_api.marshal_list_with(arp_entry_model)
     def get(self):
         return ArpEntry.query.all()
@@ -45,7 +46,7 @@ class ArpEntrysResource(Resource):
 
 
 @arp_entries_api.route("/<string:id>")
-class ArpEntryResource(Resource):
+class ArpEntryResource(AuthenticatedResource):
     @arp_entries_api.marshal_with(arp_entry_model)
     def get(self, id):
         return db.get_or_404(ArpEntry, id)
@@ -71,7 +72,7 @@ class ArpEntryResource(Resource):
 ARP_ENTRY_FILTER_FIELDS = {"ip_address", "mac_address", "vendor"}
 
 @arp_entries_api.route("/filter")
-class ArpEntryResourceFilter(Resource):
+class ArpEntryResourceFilter(AuthenticatedResource):
     @arp_entries_api.marshal_list_with(arp_entry_model)
     def get(self):
         field = request.args.get("field")

--- a/neteye/api/auth_namespace.py
+++ b/neteye/api/auth_namespace.py
@@ -47,8 +47,9 @@ class Login(Resource):
             return {'message': 'Account is disabled'}, 403
             
         login_user(user)
-        
+
         return {
+            'authentication_token': user.get_auth_token(),
             'id': user.id,
             'email': user.email,
             'username': user.username,

--- a/neteye/api/cable_namespace.py
+++ b/neteye/api/cable_namespace.py
@@ -1,9 +1,10 @@
 from flask import jsonify, request
-from flask_restx import Namespace, Resource, ValidationError, fields, abort
+from flask_restx import Namespace, ValidationError, fields, abort
 
 from neteye.api.interface_namespace import InterfaceSchema
 from neteye.api.routes import api_bp
 from neteye.cable.models import Cable
+from neteye.api.routes import AuthenticatedResource
 from neteye.extensions import api, db, ma
 
 
@@ -29,7 +30,7 @@ cable_model = cables_api.model('Cable', {
 })
 
 @cables_api.route("", "/")
-class CablesResource(Resource):
+class CablesResource(AuthenticatedResource):
     @cables_api.marshal_list_with(cable_model)
     def get(self):
         return Cable.query.all()
@@ -46,7 +47,7 @@ class CablesResource(Resource):
 
 
 @cables_api.route("/<string:id>")
-class CableResource(Resource):
+class CableResource(AuthenticatedResource):
     @cables_api.marshal_with(cable_model)
     def get(self, id):
         return db.get_or_404(Cable, id)
@@ -72,7 +73,7 @@ class CableResource(Resource):
 CABLE_FILTER_FIELDS = {"cable_type", "description", "link_speed"}
 
 @cables_api.route("/filter")
-class CableResourceFilter(Resource):
+class CableResourceFilter(AuthenticatedResource):
     @cables_api.marshal_list_with(cable_model)
     def get(self):
         field = request.args.get("field")

--- a/neteye/api/interface_namespace.py
+++ b/neteye/api/interface_namespace.py
@@ -1,8 +1,9 @@
 from flask import jsonify, request
-from flask_restx import Namespace, Resource, ValidationError, fields, abort
+from flask_restx import Namespace, ValidationError, fields, abort
 
 from neteye.api.node_namespace import NodeSchema
 from neteye.api.routes import api_bp
+from neteye.api.routes import AuthenticatedResource
 from neteye.extensions import api, db, ma
 from neteye.interface.models import Interface
 from neteye.node.models import Node
@@ -34,7 +35,7 @@ interface_model = interfaces_api.model('Interface', {
 })
 
 @interfaces_api.route("", "/")
-class InterfacesResource(Resource):
+class InterfacesResource(AuthenticatedResource):
     @interfaces_api.marshal_list_with(interface_model)
     def get(self):
         return Interface.query.all()
@@ -51,7 +52,7 @@ class InterfacesResource(Resource):
 
 
 @interfaces_api.route("/<string:id>")
-class InterfaceResource(Resource):
+class InterfaceResource(AuthenticatedResource):
     @interfaces_api.marshal_with(interface_model)
     def get(self, id):
         return db.get_or_404(Interface, id)
@@ -77,7 +78,7 @@ class InterfaceResource(Resource):
 INTERFACE_FILTER_FIELDS = {"ip_address", "name", "description", "status"}
 
 @interfaces_api.route("/filter")
-class InterfaceResourceFilter(Resource):
+class InterfaceResourceFilter(AuthenticatedResource):
     @interfaces_api.marshal_list_with(interface_model)
     def get(self):
         field = request.args.get("field")

--- a/neteye/api/node_namespace.py
+++ b/neteye/api/node_namespace.py
@@ -1,7 +1,8 @@
 from flask import jsonify, request
-from flask_restx import Namespace, Resource, ValidationError, fields, abort
+from flask_restx import Namespace, ValidationError, fields, abort
 
-from neteye.extensions import api, ma
+from neteye.api.routes import AuthenticatedResource
+from neteye.extensions import api, db, ma
 from neteye.node.models import Node
 import neteye.node.routes as node_imports
 
@@ -37,7 +38,7 @@ node_model = nodes_api.model('Node', {
 })
 
 @nodes_api.route("","/")
-class NodesResource(Resource):
+class NodesResource(AuthenticatedResource):
     @nodes_api.marshal_list_with(node_model)
     def get(self):
         return Node.query.all()
@@ -53,7 +54,7 @@ class NodesResource(Resource):
             abort(400, message=err.messages)
 
 @nodes_api.route("/<string:id>")
-class NodeResource(Resource):
+class NodeResource(AuthenticatedResource):
     @nodes_api.marshal_with(node_model)
     def get(self, id):
         return db.get_or_404(Node, id)
@@ -79,7 +80,7 @@ class NodeResource(Resource):
 NODE_FILTER_FIELDS = {"hostname", "ip_address", "device_type", "os_type"}
 
 @nodes_api.route("/filter")
-class NodeResourceFilter(Resource):
+class NodeResourceFilter(AuthenticatedResource):
     @nodes_api.marshal_list_with(node_model)
     def get(self):
         field = request.args.get("field")
@@ -91,7 +92,7 @@ class NodeResourceFilter(Resource):
 
 
 @nodes_api.route("/<string:id>/command/<string:command>")
-class NodeResourceCommand(Resource):
+class NodeResourceCommand(AuthenticatedResource):
     def get(self, id, command):
         command = command.replace("+", " ")
         node = db.get_or_404(Node, id)
@@ -100,7 +101,7 @@ class NodeResourceCommand(Resource):
 
 
 @nodes_api.route("/<string:id>/raw_command/<string:command>")
-class NodeResourceRawCommand(Resource):
+class NodeResourceRawCommand(AuthenticatedResource):
     def get(self, id, command):
         command = command.replace("+", " ")
         node = db.get_or_404(Node, id)
@@ -109,7 +110,7 @@ class NodeResourceRawCommand(Resource):
 
 
 @nodes_api.route("/<string:id>/import/node")
-class NodeImportNode(Resource):
+class NodeImportNode(AuthenticatedResource):
     @nodes_api.marshal_with(node_model)
     def post(self, id):
         node = db.get_or_404(Node, id)
@@ -118,7 +119,7 @@ class NodeImportNode(Resource):
 
 
 @nodes_api.route("/<string:id>/import/serial")
-class NodeImportSerial(Resource):
+class NodeImportSerial(AuthenticatedResource):
     def post(self, id):
         node = db.get_or_404(Node, id)
         node_imports.import_serials(node)
@@ -126,7 +127,7 @@ class NodeImportSerial(Resource):
 
 
 @nodes_api.route("/<string:id>/import/interface")
-class NodeImportInterface(Resource):
+class NodeImportInterface(AuthenticatedResource):
     def post(self, id):
         node = db.get_or_404(Node, id)
         node_imports.import_interfaces(node)
@@ -134,7 +135,7 @@ class NodeImportInterface(Resource):
 
 
 @nodes_api.route("/<string:id>/import/arp_entry")
-class NodeImportArpEntry(Resource):
+class NodeImportArpEntry(AuthenticatedResource):
     def post(self, id):
         node = db.get_or_404(Node, id)
         node_imports.import_arp_entries(node)
@@ -142,7 +143,7 @@ class NodeImportArpEntry(Resource):
 
 
 @nodes_api.route("/<string:id>/import/all_data")
-class NodeImportAll(Resource):
+class NodeImportAll(AuthenticatedResource):
     def post(self, id):
         node = db.get_or_404(Node, id)
         node_imports.import_all_data(node)

--- a/neteye/api/routes.py
+++ b/neteye/api/routes.py
@@ -1,5 +1,18 @@
-from neteye.blueprints import bp_factory
 from flask import request, redirect, url_for, render_template, flash, session
+from flask_restx import Resource
+from flask_security import auth_required
+
+from neteye.blueprints import bp_factory
 
 
 api_bp = bp_factory("api")
+
+
+class AuthenticatedResource(Resource):
+    """Flask-RestX Resource base class that requires a valid login session.
+
+    Inherit from this instead of ``Resource`` for any endpoint that must be
+    protected.  ``/api/auth/login`` (and similar public auth endpoints) should
+    continue to inherit directly from ``Resource``.
+    """
+    method_decorators = [auth_required("session", "token")]

--- a/neteye/api/serial_namespace.py
+++ b/neteye/api/serial_namespace.py
@@ -1,8 +1,9 @@
 from flask import jsonify, request
-from flask_restx import Namespace, Resource, ValidationError, fields, abort
+from flask_restx import Namespace, ValidationError, fields, abort
 
 from neteye.api.node_namespace import NodeSchema
 from neteye.api.routes import api_bp
+from neteye.api.routes import AuthenticatedResource
 from neteye.extensions import api, db, ma
 from neteye.serial.models import Serial
 
@@ -26,7 +27,7 @@ serial_model = serials_api.model('Serial', {
 })
 
 @serials_api.route("", "/")
-class SerialsResource(Resource):
+class SerialsResource(AuthenticatedResource):
     @serials_api.marshal_list_with(serial_model)
     def get(self):
         return Serial.query.all()
@@ -43,7 +44,7 @@ class SerialsResource(Resource):
 
 
 @serials_api.route("/<string:id>")
-class SerialResource(Resource):
+class SerialResource(AuthenticatedResource):
     @serials_api.marshal_with(serial_model)
     def get(self, id):
         return db.get_or_404(Serial, id)
@@ -69,7 +70,7 @@ class SerialResource(Resource):
 SERIAL_FILTER_FIELDS = {"serial_number", "product_id", "description"}
 
 @serials_api.route("/filter")
-class SerialResourceFilter(Resource):
+class SerialResourceFilter(AuthenticatedResource):
     @serials_api.marshal_list_with(serial_model)
     def get(self):
         field = request.args.get("field")

--- a/neteye/history/routes.py
+++ b/neteye/history/routes.py
@@ -9,6 +9,7 @@ from flask import (flash, jsonify, redirect, render_template, request, session,
 from sqlalchemy.sql import exists
 
 from datatables import ColumnDT, DataTables
+from flask_security import auth_required
 from neteye.api.history_namespace import (arp_entry_transaction_schema,
                                            arp_entry_transactions_schema,
                                            arp_entry_version_schema,
@@ -41,11 +42,13 @@ from .model_command_history import CommandHistory
 history_bp = bp_factory("history")
 
 @history_bp.route("/node_history")
+@auth_required()
 def node_history():
     return render_template("history/node_history.html")
 
 
 @history_bp.route("/node_history_data")
+@auth_required()
 def node_history_data():
     columns = [
         ColumnDT(node_transaction.issued_at),
@@ -81,11 +84,13 @@ def node_history_data():
 
 
 @history_bp.route("/interface_history")
+@auth_required()
 def interface_history():
     return render_template("history/interface_history.html")
 
 
 @history_bp.route("/interface_history_data")
+@auth_required()
 def interface_history_data():
     columns = [
         ColumnDT(interface_transaction.issued_at),
@@ -113,10 +118,12 @@ def interface_history_data():
 
 
 @history_bp.route("/serial_history")
+@auth_required()
 def serial_history():
     return render_template("history/serial_history.html")
 
 @history_bp.route("/serial_history_data")
+@auth_required()
 def serial_history_data():
     columns = [
         ColumnDT(serial_transaction.issued_at),
@@ -143,11 +150,13 @@ def serial_history_data():
 
 
 @history_bp.route("/cable_history")
+@auth_required()
 def cable_history():
     return render_template("history/cable_history.html")
 
 
 @history_bp.route("/cable_history_data")
+@auth_required()
 def cable_history_data():
     columns = [
         ColumnDT(cable_transaction.issued_at),
@@ -177,11 +186,13 @@ def cable_history_data():
 
 
 @history_bp.route("/arp_entry_history")
+@auth_required()
 def arp_entry_history():
     return render_template("history/arp_entry_history.html")
 
 
 @history_bp.route("/arp_entry_history_data")
+@auth_required()
 def arp_entry_history_data():
     columns = [
         ColumnDT(arp_entry_transaction.issued_at),
@@ -212,11 +223,13 @@ def arp_entry_history_data():
     return jsonify(result)
 
 @history_bp.route("/command_history")
+@auth_required()
 def command_history():
     return render_template("history/command_history.html")
 
 
 @history_bp.route("/command_history_data")
+@auth_required()
 def command_history_data():
     columns = [
         ColumnDT(CommandHistory.created_at),
@@ -235,6 +248,7 @@ def command_history_data():
     return jsonify(result)
 
 @history_bp.route("/command_history/<id>/result")
+@auth_required()
 def command_history_result(id):
     command_history = CommandHistory.get(id)
     result = json.loads(command_history.result)

--- a/neteye/troubleshoot/routes.py
+++ b/neteye/troubleshoot/routes.py
@@ -1,6 +1,7 @@
 import pandas as pd
 from dynaconf import settings
 from flask import flash, redirect, render_template, request, session, url_for
+from flask_security import auth_required
 
 from neteye.blueprints import bp_factory
 from neteye.extensions import db
@@ -12,11 +13,13 @@ troubleshoot_bp = bp_factory("troubleshoot")
 
 
 @troubleshoot_bp.route("/ping")
+@auth_required()
 def ping():
     form = PingForm()
     return render_template("/troubleshoot/ping.html", form=form)
 
 
 @troubleshoot_bp.route("/ping", methods=["POST"])
+@auth_required()
 def ping_execute():
     return render_template("/troubleshoot/ping.html")

--- a/neteye/user/routes.py
+++ b/neteye/user/routes.py
@@ -54,14 +54,14 @@ def data():
 
 
 @user_bp.route('/<id>')
-@auth_required()
+@roles_required('admin')
 def show(id):
     user = User.get(id)
     return render_template('user/show.html', user=user)
 
 
 @user_bp.route('/<id>/delete', methods=['POST'])
-@auth_required()
+@roles_required('admin')
 def delete(id):
     user = User.get(id)
     user.delete()

--- a/neteye/visualization/routes.py
+++ b/neteye/visualization/routes.py
@@ -8,6 +8,7 @@ from sqlalchemy.sql import exists
 
 from neteye.arp_entry.models import ArpEntry
 from neteye.blueprints import bp_factory
+from flask_security import auth_required
 from neteye.cable.models import Cable
 from neteye.extensions import connection_pool, db, settings
 from neteye.interface.models import Interface
@@ -25,6 +26,7 @@ intf_conv = IntfAbbrevConverter("cisco_ios")
 
 
 @visualization_bp.route("/layer1")
+@auth_required()
 def layer1():
     cables = (
         Cable.query.join(

--- a/settings.toml
+++ b/settings.toml
@@ -19,6 +19,12 @@ SECURITY_LOGIN_USER_TEMPLATE = 'login.html'
 SECURITY_REGISTER_USER_TEMPLATE = 'register.html'
 # Flask-Security-Too 5.x manages CSRF internally; disable Flask-WTF's default check
 WTF_CSRF_CHECK_DEFAULT = false
+# Token authentication for REST API / automation clients
+# Header: Authentication-Token: <token>
+SECURITY_TOKEN_AUTHENTICATION_HEADER = 'Authentication-Token'
+# Token expiry: 7 days (604800 seconds)
+# On expiry, client should re-login to obtain a new token
+SECURITY_TOKEN_MAX_AGE = 604800
 
 # Administrator Setting
 ADMIN_EMAIL = 'neteye_admin@yourcompany.com'


### PR DESCRIPTION
## Summary

- **REST API 認証**: `AuthenticatedResource` 基底クラスを追加。`auth_required("session", "token")` でブラウザとautomationクライアントの両方に対応
- **トークン認証**: ログインレスポンスに `authentication_token` を追加。有効期限7日（`SECURITY_TOKEN_MAX_AGE = 604800`）
- **Web ルート**: history（13ルート）・visualization・troubleshoot に `@auth_required()` を追加
- **IDOR修正**: `user/routes.py` の show・delete を `@roles_required('admin')` に変更

## Token 利用方法（自動化クライアント向け）

```bash
# 1. トークン取得
TOKEN=$(curl -s -X POST /api/auth/login \
  -H "Content-Type: application/json" \
  -d '{"email":"admin@example.com","password":"xxx"}' \
  | jq -r .authentication_token)

# 2. API 利用
curl /api/nodes -H "Authentication-Token: $TOKEN"
```

## Test plan

- [x] `pytest tests/` — 52テスト全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)