### PR TITLE
fix(1-H): prevent thread race on SSH_MAPPER_BASE in autodetect helper

### DIFF
--- a/neteye/lib/netmiko_utils/netmiko_autodetect_helper.py
+++ b/neteye/lib/netmiko_utils/netmiko_autodetect_helper.py
@@ -1,3 +1,5 @@
+import threading
+
 import netmiko
 from netmiko import ssh_autodetect
 from netmiko.ssh_autodetect import SSHDetect
@@ -6,47 +8,64 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# SSH_MAPPER_BASE はモジュールレベルのグローバル変数であるため、
+# 複数スレッドが同時に autodetect を実行すると競合が発生する。
+# このロックで「フィルタ置換 → autodetect() 実行 → 復元」を排他制御する。
+_mapper_lock = threading.Lock()
+
+
 def detect_device_type(node, specified_device_types: Optional[List[str]] = None):
     """
-    SSH_MAPPER_BASEを一時的に置き換えて高速デバイスタイプ検出を実現する
-    
+    SSH_MAPPER_BASE をフィルタリングして高速デバイスタイプ検出を実現する。
+
+    SSHDetect の初期化（SSH 接続確立）はロック外で行い、
+    autodetect() 呼び出しの直前だけロックを取得することで、
+    スレッド競合を防ぎつつ並列 SSH 接続を許容する。
+
     Args:
-        node: Nodeオブジェクト
-        specified_device_types: 検出対象とするデバイスタイプのリスト
-                                Noneの場合は通常の自動検出を実行
-    
+        node: Node オブジェクト
+        specified_device_types: 検出対象とするデバイスタイプのリスト。
+                                None の場合は通常の自動検出を実行。
+
     Returns:
         str: 検出されたデバイスタイプ
     """
-    # 元のSSH_MAPPER_BASEをバックアップ
-    original_mapper = ssh_autodetect.SSH_MAPPER_BASE.copy()
-    
+    params = node.gen_netmiko_params()
+    params['device_type'] = 'autodetect'
+
     try:
-        # 指定されたデバイスタイプがある場合はフィルタ、なければそのまま使用
-        if specified_device_types:
-            specified_mapper = [(device_type, autodetect_dict) 
-                                for device_type, autodetect_dict in original_mapper 
-                                if device_type in specified_device_types]
-            ssh_autodetect.SSH_MAPPER_BASE = specified_mapper
-        
-        params = node.gen_netmiko_params()
-        params['device_type'] = 'autodetect'
+        # SSH 接続確立はロック外（遅い処理を並列化するため）
         detector = SSHDetect(**params)
-        detected_type = detector.autodetect()
-        
+
+        if specified_device_types:
+            # autodetect() が参照するモジュールレベル変数の置換をロックで保護
+            with _mapper_lock:
+                original_mapper = ssh_autodetect.SSH_MAPPER_BASE
+                specified_mapper = [
+                    (device_type, autodetect_dict)
+                    for device_type, autodetect_dict in original_mapper
+                    if device_type in specified_device_types
+                ]
+                ssh_autodetect.SSH_MAPPER_BASE = specified_mapper
+                try:
+                    detected_type = detector.autodetect()
+                finally:
+                    ssh_autodetect.SSH_MAPPER_BASE = original_mapper
+        else:
+            detected_type = detector.autodetect()
+
         if detected_type:
             return detected_type
         else:
-            logger.warning(f"Could not detect device type for {node.ip_address}, falling back to cisco_ios_telnet")
+            logger.warning(
+                f"Could not detect device type for {node.ip_address}, "
+                "falling back to cisco_ios_telnet"
+            )
             return "cisco_ios_telnet"
-            
+
     except (
         netmiko.exceptions.NetMikoTimeoutException,
         netmiko.exceptions.SSHException,
     ) as err:
         logger.error(f"SSH detection failed for {node.ip_address}: {err}")
         return "cisco_ios_telnet"
-    finally:
-        # SSH_MAPPER_BASEを元に戻す（指定されたデバイスタイプがある場合のみ）
-        if specified_device_types:
-            ssh_autodetect.SSH_MAPPER_BASE = original_mapper


### PR DESCRIPTION
## Summary
- `detect_device_type()` が `ssh_autodetect.SSH_MAPPER_BASE`（netmiko のモジュールレベル変数）を一時的に書き換えていたため、複数スレッドが同時に autodetect を実行すると Thread B が Thread A のフィルタ済みマッパーを誤読する競合が発生していた
- モジュールレベルの `threading.Lock`（`_mapper_lock`）を導入し、「マッパー置換 → `autodetect()` 実行 → 復元」の区間を排他制御
- 遅い SSH 接続確立（`SSHDetect.__init__`）はロック外に残し、並列接続のスループットを維持

## Test plan
- [ ] `device_type=autodetect` でノード登録が正常に動作することを確認
- [ ] 複数ノードを同時に autodetect 登録しても正しいデバイスタイプが検出されることを確認