### PR TITLE
refactor: replace _with_history twin methods with @record_history decorator

### DIFF
--- a/neteye/api/node_namespace.py
+++ b/neteye/api/node_namespace.py
@@ -1,5 +1,6 @@
 from flask import jsonify, request
 from flask_restx import Namespace, ValidationError, fields, abort
+from flask_security import current_user
 
 from neteye.api.routes import AuthenticatedResource
 from neteye.extensions import api, db, ma
@@ -96,7 +97,7 @@ class NodeResourceCommand(AuthenticatedResource):
     def get(self, id, command):
         command = command.replace("+", " ")
         node = db.get_or_404(Node, id)
-        result = node.command(command)
+        result = node.command(command, current_user.email)
         return jsonify(result)
 
 
@@ -105,7 +106,7 @@ class NodeResourceRawCommand(AuthenticatedResource):
     def get(self, id, command):
         command = command.replace("+", " ")
         node = db.get_or_404(Node, id)
-        result = node.raw_command(command)
+        result = node.raw_command(command, current_user.email)
         return jsonify(result)
 
 

--- a/neteye/node/models.py
+++ b/neteye/node/models.py
@@ -1,3 +1,4 @@
+import functools
 import json
 
 import napalm
@@ -18,6 +19,25 @@ from neteye.serial.models import Serial
 from neteye.history.model_command_history import CommandHistory
 from neteye.lib.scrapli_utils import ScrapliCommunityHelper
 from neteye.lib.netmiko_utils.netmiko_autodetect_helper import detect_device_type
+
+def record_history(func):
+    """コマンド実行結果を CommandHistory に記録するデコレータ。
+    session_user を渡した場合のみ保存、省略すれば保存しない（接続テスト等）。
+    """
+    @functools.wraps(func)
+    def wrapper(self, command, session_user=None):
+        result = func(self, command)
+        if session_user is not None:
+            CommandHistory(
+                username=session_user,
+                node_id=self.id,
+                hostname=self.hostname,
+                command=command,
+                result=json.dumps(result)
+            ).add()
+        return result
+    return wrapper
+
 
 DRIVER_TYPE_NETMIKO = "netmiko"
 DRIVER_TYPE_SCRAPLI = "scrapli"
@@ -148,36 +168,21 @@ class Node(Base):
         else:
             self.napalm_driver = NOT_SUPPORTED
 
-    def command_with_history(self, command, session_user):
-        result = self.command(command)
-        command_history = CommandHistory(username=session_user, node_id=self.id, hostname=self.hostname, command=command, result=json.dumps(result))
-        command_history.add()
-        return result
-
+    @record_history
     def command(self, command):
         if not self.scrapli_driver == NOT_SUPPORTED:
             return self.scrapli_command(command)
         else:
             return self.netmiko_command(command)
 
-    def raw_command_with_history(self, command, session_user):
-        result = self.raw_command(command)
-        command_history = CommandHistory(username=session_user, node_id=self.id, hostname=self.hostname, command=command, result=json.dumps(result))
-        command_history.add()
-        return result
-
+    @record_history
     def raw_command(self, command):
         if not self.scrapli_driver == NOT_SUPPORTED:
             return self.scrapli_raw_command(command)
         else:
             return self.netmiko_raw_command(command)
 
-    def netmiko_command_with_history(self, command, session_user):
-        result = self.netmiko_command(command)
-        command_history = CommandHistory(username=session_user, node_id=self.id, hostname=self.hostname, command=command, result=json.dumps(result))
-        command_history.add()
-        return result
-
+    @record_history
     def netmiko_command(self, command):
         if not connection_pool.exists(self, DRIVER_TYPE_NETMIKO):
             connection_pool.add_connection(self, DRIVER_TYPE_NETMIKO)
@@ -187,24 +192,14 @@ class Node(Base):
         parsed = ntc_template_utils.parse(platform=platform, command=command, data=raw_output)
         return parsed if parsed else raw_output
 
-    def netmiko_raw_command_with_history(self, command, session_user):
-        result = self.netmiko_raw_command(command)
-        command_history = CommandHistory(username=session_user, node_id=self.id, hostname=self.hostname, command=command, result=json.dumps(result))
-        command_history.add()
-        return result
-
+    @record_history
     def netmiko_raw_command(self, command):
         if not connection_pool.exists(self, DRIVER_TYPE_NETMIKO):
             connection_pool.add_connection(self, DRIVER_TYPE_NETMIKO)
         conn = connection_pool.get_connection(self, DRIVER_TYPE_NETMIKO)
         return conn.send_command(command, use_textfsm=False)
 
-    def scrapli_command_with_history(self, command, session_user):
-        result = self.scrapli_command(command)
-        command_history = CommandHistory(username=session_user, node_id=self.id, hostname=self.hostname, command=command, result=json.dumps(result))
-        command_history.add()
-        return result
-
+    @record_history
     def scrapli_command(self, command):
         if not connection_pool.exists(self, DRIVER_TYPE_SCRAPLI):
             connection_pool.add_connection(self, DRIVER_TYPE_SCRAPLI)
@@ -215,12 +210,7 @@ class Node(Base):
         parsed = ntc_template_utils.parse(platform=platform, command=command, data=raw_output)
         return parsed if parsed else raw_output
 
-    def scrapli_raw_command_with_history(self, command, session_user):
-        result = self.scrapli_raw_command(command)
-        command_history = CommandHistory(username=session_user, node_id=self.id, hostname=self.hostname, command=command, result=json.dumps(result))
-        command_history.add()
-        return result
-
+    @record_history
     def scrapli_raw_command(self, command):
         if not connection_pool.exists(self, DRIVER_TYPE_SCRAPLI):
             connection_pool.add_connection(self, DRIVER_TYPE_SCRAPLI)

--- a/neteye/node/routes.py
+++ b/neteye/node/routes.py
@@ -280,7 +280,7 @@ def show_run(id):
         if not node:
             flash(f"Node with ID {id} not found", "danger")
             return redirect(url_for("node.index"))
-        result = node.raw_command_with_history(command, current_user.email)
+        result = node.raw_command(command, current_user.email)
         result = result.replace("\r\n", "<br />").replace("\n", "<br />")
         return render_template("node/command.html", result=result, command=command)
     except Exception as err:
@@ -297,7 +297,7 @@ def show_inventory(id):
         if not node:
             flash(f"Node with ID {id} not found", "danger")
             return redirect(url_for("node.index"))
-        result = node.command_with_history(command, current_user.email)
+        result = node.command(command, current_user.email)
         return render_template("node/parsed_command.html", result=result, command=command)
     except Exception as err:
         report_exception(err, f"Error executing '{command}' for node {id}")
@@ -313,7 +313,7 @@ def show_version(id):
         if not node:
             flash(f"Node with ID {id} not found", "danger")
             return redirect(url_for("node.index"))
-        result = node.command_with_history(command, current_user.email)
+        result = node.command(command, current_user.email)
         return render_template("node/parsed_command.html", result=result, command=command)
     except Exception as err:
         report_exception(err, f"Error executing '{command}' for node {id}")
@@ -329,7 +329,7 @@ def show_ip_int_breif(id):
         if not node:
             flash(f"Node with ID {id} not found", "danger")
             return redirect(url_for("node.index"))
-        result = node.command_with_history(command, current_user.email)
+        result = node.command(command, current_user.email)
         return render_template("node/parsed_command.html", result=result, command=command)
     except Exception as err:
         report_exception(err, f"Error executing '{command}' for node {id}")
@@ -345,7 +345,7 @@ def show_interfaces_description(id):
         if not node:
             flash(f"Node with ID {id} not found", "danger")
             return redirect(url_for("node.index"))
-        result = node.command_with_history(command, current_user.email)
+        result = node.command(command, current_user.email)
         return render_template("node/parsed_command.html", result=result, command=command)
     except Exception as err:
         report_exception(err, f"Error executing '{command}' for node {id}")
@@ -361,7 +361,7 @@ def show_ip_arp(id):
         if not node:
             flash(f"Node with ID {id} not found", "danger")
             return redirect(url_for("node.index"))
-        result = node.command_with_history(command, current_user.email)
+        result = node.command(command, current_user.email)
         return render_template("node/show_ip_arp.html", result=result, command=command)
     except Exception as err:
         report_exception(err, f"Error executing '{command}' for node {id}")
@@ -377,7 +377,7 @@ def show_ip_route(id):
         if not node:
             flash(f"Node with ID {id} not found", "danger")
             return redirect(url_for("node.index"))
-        result = node.command_with_history(command, current_user.email)
+        result = node.command(command, current_user.email)
         return render_template("node/show_ip_route.html", result=result, command=command)
     except Exception as err:
         report_exception(err, f"Error executing '{command}' for node {id}")
@@ -393,7 +393,7 @@ def command(id, command):
         if not node:
             flash(f"Node with ID {id} not found", "danger")
             return redirect(url_for("node.index"))
-        result = node.command_with_history(command, current_user.email)
+        result = node.command(command, current_user.email)
         if isinstance(result, str):
             result = result.replace("\r\n", "<br />").replace("\n", "<br />")
             return render_template("node/command.html", result=result, command=command)
@@ -413,7 +413,7 @@ def raw_command(id, command):
             flash(f"Node with ID {id} not found", "danger")
             return redirect(url_for("node.index"))
         result = (
-            node.raw_command_with_history(command, current_user.email)
+            node.raw_command(command, current_user.email)
             .replace("\r\n", "<br />")
             .replace("\n", "<br />")
         )
@@ -432,7 +432,7 @@ def netmiko_command(id, command):
         if not node:
             flash(f"Node with ID {id} not found", "danger")
             return redirect(url_for("node.index"))
-        result = node.netmiko_command_with_history(command, current_user.email)
+        result = node.netmiko_command(command, current_user.email)
         if isinstance(result, str):
             result = result.replace("\r\n", "<br />").replace("\n", "<br />")
             return render_template("node/command.html", result=result, command=command)
@@ -452,7 +452,7 @@ def netmiko_raw_command(id, command):
             flash(f"Node with ID {id} not found", "danger")
             return redirect(url_for("node.index"))
         result = (
-            node.netmiko_raw_command_with_history(command, current_user.email)
+            node.netmiko_raw_command(command, current_user.email)
             .replace("\r\n", "<br />")
             .replace("\n", "<br />")
         )
@@ -471,7 +471,7 @@ def scrapli_command(id, command):
         if not node:
             flash(f"Node with ID {id} not found", "danger")
             return redirect(url_for("node.index"))
-        result = node.scrapli_command_with_history(command, current_user.email)
+        result = node.scrapli_command(command, current_user.email)
         if isinstance(result, str):
             result = result.replace("\r\n", "<br />").replace("\n", "<br />")
             return render_template("node/command.html", result=result, command=command)
@@ -491,7 +491,7 @@ def scrapli_raw_command(id, command):
             flash(f"Node with ID {id} not found", "danger")
             return redirect(url_for("node.index"))
         result = (
-            node.scrapli_raw_command_with_history(command, current_user.email)
+            node.scrapli_raw_command(command, current_user.email)
             .replace("\r\n", "<br />")
             .replace("\n", "<br />")
         )
@@ -730,7 +730,7 @@ def import_common(node, model):
     # get data for each command and merge into after_records
     for command in import_command_mapper.get_commands(import_type):
         # execute import command and get result
-        result = node.command_with_history(command, current_user.email)
+        result = node.command(command, current_user.email)
 
         if isinstance(result, list):
             index = import_command_mapper.get_index(import_type, command)
@@ -789,7 +789,7 @@ def import_node_data(node):
     import_type = IMPORT_TYPES[Node]
     
     for command in import_command_mapper.get_commands(import_type):
-        result = node.command_with_history(command, current_user.email)
+        result = node.command(command, current_user.email)
         if isinstance(result, list):
             index = import_command_mapper.get_index(import_type, command)
             fields = import_command_mapper.get_fields(import_type, command)


### PR DESCRIPTION
## Summary
- Node モデルに6ペア存在した `command` / `command_with_history` パターンを `@record_history` デコレータで統合
- `session_user` を渡せば履歴保存、省略すれば保存しない（接続テスト用 `raw_command('\n')` はそのまま）
- API 経由のコマンド実行も `current_user.email` を渡して履歴に記録されるよう修正

## Test plan
- [ ] 38 tests passed
- [ ] routes.py からの import は `_with_history` 参照がゼロであることを確認
- [ ] API の command/raw_command が履歴に記録されることを確認