### PR TITLE
fix: replace backref with back_populates to resolve SAWarning on relationships

### DIFF
--- a/neteye/interface/models.py
+++ b/neteye/interface/models.py
@@ -1,6 +1,6 @@
 from sqlalchemy import (Boolean, Column, DateTime, Float, ForeignKey, Integer,
                         String, UniqueConstraint)
-from sqlalchemy.orm import backref, relationship
+from sqlalchemy.orm import relationship
 
 from neteye.base.models import Base
 from neteye.lib.intf_abbrev.intf_abbrev import IntfAbbrevConverter
@@ -14,7 +14,7 @@ class Interface(Base):
     KEY = "name"
 
     node_id = Column(String, ForeignKey("nodes.id", ondelete="CASCADE"), nullable=False)
-    node = relationship("Node")
+    node = relationship("Node", back_populates="interfaces")
     name = Column(String, nullable=False)
     description = Column(String, default="")
     ip_address = Column(String)

--- a/neteye/node/models.py
+++ b/neteye/node/models.py
@@ -69,12 +69,12 @@ class Node(Base):
     enable = Column(String)
     interfaces = relationship(
         "Interface",
-        backref="nodes",
+        back_populates="node",
         lazy="joined",
         cascade="save-update, merge, delete",
     )
     serials = relationship(
-        "Serial", backref="nodes", lazy="joined", cascade="save-update, merge, delete"
+        "Serial", back_populates="node", lazy="joined", cascade="save-update, merge, delete"
     )
 
     def __init__(self, **kwargs):

--- a/neteye/serial/models.py
+++ b/neteye/serial/models.py
@@ -1,6 +1,6 @@
 from sqlalchemy import (Boolean, Column, DateTime, Float, ForeignKey, Integer,
                         String)
-from sqlalchemy.orm import backref, relationship
+from sqlalchemy.orm import relationship
 
 from neteye.base.models import Base
 
@@ -15,7 +15,7 @@ class Serial(Base):
     product_id = Column(String)
     description = Column(String, default="")
     node_id = Column(String, ForeignKey("nodes.id", ondelete="CASCADE"), nullable=False)
-    node = relationship("Node")
+    node = relationship("Node", back_populates="serials")
 
     def __repr__(self):
         return "serial_id={id} serial_number={serial_number} product_id={product_id} node_id={node_id}".format(


### PR DESCRIPTION
## Summary
- `Node.interfaces` / `Node.serials` の `backref="nodes"` と `Interface.node` / `Serial.node` の手動定義が衝突し、起動時に SAWarning が4本出ていた
- `back_populates` で両側を明示的に紐付けて解消

## Test plan
- [ ] 38 tests passed
- [ ] 起動時の SAWarning（relationship 関連）が消えることを確認