### PR TITLE
fix: pin bcrypt<4.0.0 for passlib 1.7.x compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ Flask-Babel==3.1.0
 Flask-Bootstrap==3.3.7.1
 Flask-Login==0.6.3
 Flask-Security-Too==5.3.2
+bcrypt<4.0.0  # passlib 1.7.x is incompatible with bcrypt 4.x (72-byte password limit)
 Flask-WTF==1.1.2
 flask-marshmallow>=1.0.0,<2.0
 flask-nav==0.6


### PR DESCRIPTION
## Summary

- `requirements.txt` に `bcrypt<4.0.0` を追加

## Background

passlib 1.7.x は内部の動作確認で 73 バイトのパスワードを使用するが、bcrypt 4.x は 72 バイト超のパスワードで `ValueError` を raise するため CI が失敗していた。

passlib の upstream が bcrypt 4.x に対応するまで `bcrypt<4.0.0` で固定する。