### PR TITLE
build: bump Flask 3.1.3, Werkzeug 3.1.6, Flask-Babel 4.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-Flask==2.3.3
-Werkzeug==2.3.8
-Flask-Babel==3.1.0
+Flask==3.1.3
+Werkzeug==3.1.6
+Flask-Babel==4.0.0
 Flask-Bootstrap==3.3.7.1
 Flask-Login==0.6.3
 Flask-Security-Too==5.3.2


### PR DESCRIPTION
## Summary

- Flask 2.3.3 → 3.1.3
- Werkzeug 2.3.8 → 3.1.6
- Flask-Babel 3.1.0 → 4.0.0（Flask 3.x で `locked_cached_property` が削除されたため）

## Test

- 38 tests passed locally

## Fixes

- Werkzeug: safe_join() Windows device name issues (medium)
- Werkzeug: debugger RCE in debug mode (high)
- Werkzeug: resource exhaustion on multipart form parsing (medium)
- Flask: missing Vary: Cookie header (low)