### PR TITLE
build: bump Flask-Security-Too 5.8.0, add argon2_cffi, remove bcrypt pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,9 @@ Werkzeug==3.1.6
 Flask-Babel==4.0.0
 Flask-Bootstrap==3.3.7.1
 Flask-Login==0.6.3
-Flask-Security-Too==5.3.2
-bcrypt<4.0.0  # passlib 1.7.x is incompatible with bcrypt 4.x (72-byte password limit)
+Flask-Security-Too==5.8.0
+bcrypt  # required by paramiko (SSH key encryption)
+argon2_cffi  # Flask-Security-Too 5.5+ uses argon2 as default password hash
 Flask-WTF==1.1.2
 flask-marshmallow>=1.0.0,<2.0
 flask-nav==0.6


### PR DESCRIPTION
## Summary

- Flask-Security-Too 5.3.2 → 5.8.0（オープンリダイレクト脆弱性の修正）
- `argon2_cffi` を追加（FST 5.5+ のデフォルトパスワードハッシュが argon2 に変更）
- `bcrypt<4.0.0` の制約を撤廃（passlib が libpass に置き換わり bcrypt 4.x が互換）

## Background

FST 5.8.0 は passlib の代わりに libpass を使用するため、bcrypt の 72 バイト制限問題が解消された。
bcrypt 自体は paramiko (SSH 鍵暗号化) のために引き続き必要。

## Test

- 38 tests passed locally