### PR TITLE
fix: hide unimplemented nav items (Layer 2, Troubleshoot)

### DIFF
--- a/neteye/base/templates/base_template.html
+++ b/neteye/base/templates/base_template.html
@@ -130,25 +130,9 @@
                         <li class="nav-item">
                             <a class="nav-link" href="/visualization/layer1">Layer 1</a>
                         </li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="/visualization/layer2">Layer 2</a>
-                        </li>
                     </ul>
                 </li>
-                <li class="nav-item nav-dropdown">
-                    <a class="nav-link nav-dropdown-toggle" href="#">
-                        Troubleshoot<br />
-                        (Comming Soon)
-                    </a>
-                    <ul class="nav-dropdown-items">
-                        <li class="nav-item">
-                            <a class="nav-link" href="/troubleshoot/ping">Ping</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="/troubleshoot/traceroute">Traceroute</a>
-                        </li>
-                    </ul>
-                </li>
+                {# Troubleshoot menu hidden until features are fully implemented #}
                 <li class="nav-item nav-dropdown">
                     <a class="nav-link nav-dropdown-toggle" href="#">
                         History


### PR DESCRIPTION
## Summary

- `Layer 2` をナビから非表示（未実装、404）
- `Troubleshoot` メニュー全体を非表示（Ping はスタブのみ、Traceroute は未実装）
- `(Comming Soon)` 表記を削除