### PR TITLE
refactor: suppress 304 responses and improve variable names in WerkzeugAccessLogFilter

### DIFF
--- a/neteye/lib/utils/werkzeug_access_log_filter.py
+++ b/neteye/lib/utils/werkzeug_access_log_filter.py
@@ -3,17 +3,25 @@ import re
 
 
 class WerkzeugAccessLogFilter(logging.Filter):
-    """Strip werkzeug's built-in timestamp from access log messages.
+    """Clean up werkzeug access log messages.
 
-    werkzeug embeds its own timestamp in every access log line:
+    Applies two transformations:
 
-        127.0.0.1 - - [10/May/2026 19:29:22] "GET /node/ HTTP/1.1" 200 -
+    1. Remove redundant werkzeug timestamp.
+       werkzeug embeds its own timestamp in every access log line:
 
-    When logging.basicConfig (or any handler) already prepends a timestamp,
-    this results in the time appearing twice on every line.  This filter
-    removes the redundant werkzeug timestamp so the output becomes:
+           127.0.0.1 - - [10/May/2026 19:29:22] "GET /node/ HTTP/1.1" 200 -
 
-        127.0.0.1 - - "GET /node/ HTTP/1.1" 200 -
+       When logging.basicConfig (or any handler) already prepends a timestamp,
+       this results in the time appearing twice on every line.  This filter
+       removes the redundant werkzeug timestamp so the output becomes:
+
+           127.0.0.1 - - "GET /node/ HTTP/1.1" 200 -
+
+    2. Suppress 304 Not Modified responses.
+       304 responses indicate browser cache hits on static files (CSS, JS,
+       images). They carry no diagnostic value in normal operation and add
+       noise that buries meaningful application requests.
 
     Why not suppress werkzeug logs entirely?
     Access logs are useful for debugging request flow. The goal is to keep
@@ -25,12 +33,20 @@ class WerkzeugAccessLogFilter(logging.Filter):
     to the 'werkzeug' logger is the least-invasive approach.
     """
 
-    _TIMESTAMP_RE = re.compile(r" \[\d{2}/\w{3}/\d{4} \d{2}:\d{2}:\d{2}\]")
+    _WERKZEUG_TIMESTAMP_RE = re.compile(r" \[\d{2}/\w{3}/\d{4} \d{2}:\d{2}:\d{2}\]")
+    _HTTP_304_RE = re.compile(r'" 304 ')
 
     def filter(self, record: logging.LogRecord) -> bool:
-        raw_msg = record.getMessage()
-        stripped = self._TIMESTAMP_RE.sub("", raw_msg)
-        if stripped != raw_msg:
-            record.msg = stripped
+        msg = record.getMessage()
+
+        # Suppress 304 Not Modified — static file cache hits, no diagnostic value.
+        if self._HTTP_304_RE.search(msg):
+            return False
+
+        # Remove the redundant werkzeug timestamp if present.
+        msg_without_timestamp = self._WERKZEUG_TIMESTAMP_RE.sub("", msg)
+        if msg_without_timestamp != msg:
+            record.msg = msg_without_timestamp
             record.args = ()
+
         return True


### PR DESCRIPTION
## Summary

- 304 Not Modified をログから完全除外（静的ファイルのキャッシュヒット、診断価値なし）
- 変数名を意味のある名前に改善（`_TIMESTAMP_RE` → `_WERKZEUG_TIMESTAMP_RE`、`stripped` → `msg_without_timestamp`）
- docstring を2つの処理に対応した内容に更新