### PR TITLE
fix: hide Visualization menu until features are fully implemented

### DIFF
--- a/neteye/base/templates/base_template.html
+++ b/neteye/base/templates/base_template.html
@@ -121,17 +121,7 @@
                         Arp Entry
                     </a>
                 </li>
-                <li class="nav-item nav-dropdown">
-                    <a class="nav-link nav-dropdown-toggle" href="#">
-                        Visualization<br />
-                        (Comming Soon)
-                    </a>
-                    <ul class="nav-dropdown-items">
-                        <li class="nav-item">
-                            <a class="nav-link" href="/visualization/layer1">Layer 1</a>
-                        </li>
-                    </ul>
-                </li>
+                {# Visualization menu hidden until features are fully implemented #}
                 {# Troubleshoot menu hidden until features are fully implemented #}
                 <li class="nav-item nav-dropdown">
                     <a class="nav-link nav-dropdown-toggle" href="#">


### PR DESCRIPTION
## Summary

- Visualization メニュー全体を非表示（Layer 1 の完成度が不十分）
- `(Comming Soon)` 表記も削除