### PR TITLE
refactor: rename get_ping_interrupt_char to get_interrupt_char

### DIFF
--- a/neteye/lib/troubleshoot_command_builder.py
+++ b/neteye/lib/troubleshoot_command_builder.py
@@ -218,7 +218,7 @@ def get_troubleshoot_builder(device_type: str) -> TroubleshootBuilder:
 # ── Ping interrupt sequences ──────────────────────────────────────────
 # Sent to the device when the user cancels a running ping.
 
-_PING_INTERRUPT_CHARS: dict[str, str] = {
+_INTERRUPT_CHARS: dict[str, str] = {
     "cisco_ios":      "\x1e",   # Ctrl+Shift+6 — Cisco standard ping interrupt
     "cisco_xe":       "\x1e",
     "cisco_nxos":     "\x1e",
@@ -231,9 +231,10 @@ _PING_INTERRUPT_CHARS: dict[str, str] = {
 }
 
 
-def get_ping_interrupt_char(device_type: str) -> str:
-    """Return the character sequence that interrupts a running ping for the given device_type.
+def get_interrupt_char(device_type: str) -> str:
+    """Return the character sequence that interrupts a running command for the given device_type.
 
+    Used to abort long-running commands (ping, traceroute, etc.) mid-execution.
     Falls back to Ctrl+C (\\x03) for unknown device types.
     """
-    return _PING_INTERRUPT_CHARS.get(device_type, "\x03")
+    return _INTERRUPT_CHARS.get(device_type, "\x03")

--- a/neteye/troubleshoot/routes.py
+++ b/neteye/troubleshoot/routes.py
@@ -10,7 +10,7 @@ from neteye.history.model_command_history import CommandHistory
 from neteye.interface.models import Interface
 from neteye.lib.troubleshoot_command_builder import (
     UnsupportedDeviceTypeError,
-    get_ping_interrupt_char,
+    get_interrupt_char,
     get_troubleshoot_builder,
 )
 from neteye.lib.utils.report_exception import report_exception
@@ -229,7 +229,7 @@ def ping_stream():
 
         except GeneratorExit:
             # Client cancelled the stream — send device-specific interrupt to stop the ping.
-            interrupt_char = get_ping_interrupt_char(node.device_type)
+            interrupt_char = get_interrupt_char(node.device_type)
             try:
                 conn.write_channel(interrupt_char)
                 time.sleep(0.2)


### PR DESCRIPTION
## Summary

- `get_ping_interrupt_char()` → `get_interrupt_char()` — the interrupt character is not ping-specific and will be reused for traceroute
- `_PING_INTERRUPT_CHARS` → `_INTERRUPT_CHARS` — internal dict renamed for consistency

## Test plan

- [ ] `ENV_FOR_DYNACONF=testing python -m pytest` passes (66 tests)