### PR TITLE
fix: auto-scroll to [Cancelled] after cancel button click

### DIFF
--- a/neteye/troubleshoot/templates/troubleshoot/ping.html
+++ b/neteye/troubleshoot/templates/troubleshoot/ping.html
@@ -48,7 +48,9 @@
          if (es) { es.close(); es = null; }
          $cancel.hide();
          $('#submit').prop('disabled', false).val('Submit');
-         $('#result-output').text($('#result-output').text() + '\n[Cancelled]');
+         var $output = $('#result-output');
+         $output.text($output.text() + '\n[Cancelled]');
+         $output[0].scrollTop = $output[0].scrollHeight;
      });
 
      $('#ping').on('submit', function(e) {


### PR DESCRIPTION
## Summary

After clicking Cancel, `[Cancelled]` was appended to the output area but the view did not scroll to show it — the user had to scroll manually. Added `scrollTop = scrollHeight` after the text update, mirroring the same pattern used in the SSE `onmessage` handler.

## Test plan

- [ ] Run a long ping, click Cancel mid-stream — `[Cancelled]` appears at the bottom of the visible output without manual scrolling