### PR TITLE
fix: correct form id on submit button in serial edit template

### DIFF
--- a/neteye/serial/templates/serial/edit.html
+++ b/neteye/serial/templates/serial/edit.html
@@ -34,7 +34,7 @@
         </form>
     </div>
     <div class="card-footer">
-        {{ form.submit(class_="btn btn-sm btn-primary", form="serial_edit") }}
+        {{ form.submit(class_="btn btn-sm btn-primary", form="serial_update") }}
         {{ form.reset(type="reset", class_="btn btn-sm btn-danger", form="serial_update") }}
     </div>
 </div>


### PR DESCRIPTION
## Summary

- Submit button had `form="serial_edit"` but the form element's id is `serial_update"` — a mismatch that causes the submit button to do nothing in spec-compliant browsers
- Changed to `form="serial_update"` to match the form id

## Test plan

- [ ] Open Serial edit page, fill in a field, click Submit — form submits correctly