### PR TITLE
refactor: extract magic numbers to constants and add SSE message helpers

### DIFF
--- a/neteye/node/forms.py
+++ b/neteye/node/forms.py
@@ -2,12 +2,14 @@ from flask_wtf import FlaskForm
 from wtforms import IntegerField, PasswordField, StringField, SubmitField
 from wtforms.validators import InputRequired, IPAddress
 
+DEFAULT_SSH_PORT = 22
+
 
 class NodeForm(FlaskForm):
     hostname = StringField("Hostname:", validators=[InputRequired()])
     description = StringField("Description:")
     ip_address = StringField("IP Address:", validators=[InputRequired(), IPAddress()])
-    port = IntegerField("Port:", default=22, validators=[InputRequired()])
+    port = IntegerField("Port:", default=DEFAULT_SSH_PORT, validators=[InputRequired()])
     device_type = StringField("Device Type:", default="autodetect", validators=[InputRequired()])
     napalm_driver = StringField("Napalm Driver:")
     scrapli_driver = StringField("Scrapli Driver:")

--- a/neteye/troubleshoot/forms.py
+++ b/neteye/troubleshoot/forms.py
@@ -11,6 +11,12 @@ def get_nodes():
     return Node.query.all()
 
 
+# Ping form defaults
+PING_DEFAULT_COUNT     = 5
+PING_DEFAULT_DATA_SIZE = 100
+PING_DEFAULT_TIMEOUT   = 2
+
+
 class PingForm(FlaskForm):
     dst_ip_address = StringField("Destination IP Address:", validators=[DataRequired()])
     src_node = QuerySelectField(
@@ -24,17 +30,17 @@ class PingForm(FlaskForm):
     count = IntegerField(
         "Count:",
         validators=[DataRequired(), NumberRange(min=1, max=settings.PING_MAX_COUNT)],
-        default=5,
+        default=PING_DEFAULT_COUNT,
     )
     data_size = IntegerField(
         "Data Size:",
         validators=[DataRequired(), NumberRange(min=1, max=settings.PING_MAX_DATA_SIZE)],
-        default=100,
+        default=PING_DEFAULT_DATA_SIZE,
     )
     timeout = IntegerField(
         "Timeout:",
         validators=[DataRequired(), NumberRange(min=1, max=settings.PING_MAX_TIMEOUT)],
-        default=2,
+        default=PING_DEFAULT_TIMEOUT,
     )
     submit = SubmitField("Submit")
     reset = SubmitField("Reset")

--- a/neteye/troubleshoot/routes.py
+++ b/neteye/troubleshoot/routes.py
@@ -16,12 +16,25 @@ from neteye.lib.troubleshoot_command_builder import (
 from neteye.lib.utils.report_exception import report_exception
 from neteye.node.models import Node
 
-from .forms import PingForm
+from .forms import PING_DEFAULT_COUNT, PING_DEFAULT_DATA_SIZE, PING_DEFAULT_TIMEOUT, PingForm
 
 logger = logging.getLogger(__name__)
 
 troubleshoot_bp = bp_factory("troubleshoot")
 
+
+# ── SSE helpers — shared by all streaming routes ──────────────────────
+
+def _sse_message(text: str) -> str:
+    """Format text as a single SSE data line (data: <text>\\n\\n)."""
+    return f"data: {text}\n\n"
+
+
+_SSE_DONE      = _sse_message("[DONE]")
+_SSE_SEPARATOR = _sse_message("")   # blank line between header info and streaming output
+
+
+# ── Annotation helpers ────────────────────────────────────────────────
 
 def _annotate_ip(ip_address: str) -> str | None:
     """Look up an IP address in the Node and Interface tables and return an annotation string.
@@ -141,21 +154,21 @@ def ping_stream():
     dst_ip = request.args.get("dst_ip", "").strip()
     src_ip = request.args.get("src_ip", "").strip() or None
     vrf = request.args.get("vrf", "").strip() or None
-    count = min(max(request.args.get("count", 5, type=int), 1), settings.PING_MAX_COUNT)
-    timeout = min(max(request.args.get("timeout", 2, type=int), 1), settings.PING_MAX_TIMEOUT)
-    size = request.args.get("size", 100, type=int)
+    count = min(max(request.args.get("count", PING_DEFAULT_COUNT, type=int), 1), settings.PING_MAX_COUNT)
+    timeout = min(max(request.args.get("timeout", PING_DEFAULT_TIMEOUT, type=int), 1), settings.PING_MAX_TIMEOUT)
+    size = request.args.get("size", PING_DEFAULT_DATA_SIZE, type=int)
 
     node = Node.query.filter_by(id=node_id).first() if node_id else None
 
     def generate():
         # --- Validation ---
         if not node:
-            yield "data: ERROR: Node not found\n\n"
-            yield "data: [DONE]\n\n"
+            yield _sse_message("ERROR: Node not found")
+            yield _SSE_DONE
             return
         if not dst_ip:
-            yield "data: ERROR: Destination IP is required\n\n"
-            yield "data: [DONE]\n\n"
+            yield _sse_message("ERROR: Destination IP is required")
+            yield _SSE_DONE
             return
 
         # --- Build command ---
@@ -170,8 +183,8 @@ def ping_stream():
                 size=size,
             )
         except UnsupportedDeviceTypeError:
-            yield f"data: ERROR: Ping is not supported for device type: {node.device_type}\n\n"
-            yield "data: [DONE]\n\n"
+            yield _sse_message(f"ERROR: Ping is not supported for device type: {node.device_type}")
+            yield _SSE_DONE
             return
 
         commands = command if isinstance(command, list) else [command]
@@ -180,17 +193,17 @@ def ping_stream():
         # --- Emit header info ---
         dst_annotation = _annotate_ip(dst_ip)
         annotation_suffix = f" -> {dst_annotation}" if dst_annotation else ""
-        yield f"data: Destination : {dst_ip}{annotation_suffix}\n\n"
-        yield f"data: Command     : {command_str}\n\n"
-        yield "data: \n\n"
+        yield _sse_message(f"Destination : {dst_ip}{annotation_suffix}")
+        yield _sse_message(f"Command     : {command_str}")
+        yield _SSE_SEPARATOR
 
         # --- Open dedicated connection (not from pool) ---
         try:
             conn = node.gen_netmiko_connection()
         except Exception as err:
             report_exception(err, "Ping connection failed")
-            yield f"data: ERROR: Connection failed: {err}\n\n"
-            yield "data: [DONE]\n\n"
+            yield _sse_message(f"ERROR: Connection failed: {err}")
+            yield _SSE_DONE
             return
 
         # --- Stream output ---
@@ -209,7 +222,7 @@ def ping_stream():
                         buffer += chunk
                         for line in chunk.splitlines():
                             if line.strip():
-                                yield f"data: {line}\n\n"
+                                yield _sse_message(line)
                         if prompt in buffer:
                             break
                     else:
@@ -239,14 +252,14 @@ def ping_stream():
 
         except Exception as err:
             report_exception(err, "Ping execution failed")
-            yield f"data: ERROR: {err}\n\n"
+            yield _sse_message(f"ERROR: {err}")
         finally:
             try:
                 conn.disconnect()
             except Exception:
                 pass
 
-        yield "data: [DONE]\n\n"
+        yield _SSE_DONE
 
     return Response(
         stream_with_context(generate()),


### PR DESCRIPTION
## Summary

- Add `PING_DEFAULT_COUNT` / `PING_DEFAULT_DATA_SIZE` / `PING_DEFAULT_TIMEOUT` constants to `troubleshoot/forms.py`; use in `PingForm` defaults and `ping_stream` `request.args.get()` defaults (eliminates duplicate hardcoded values)
- Add `DEFAULT_SSH_PORT = 22` to `node/forms.py`
- Add `_sse_message()` helper, `_SSE_DONE`, and `_SSE_SEPARATOR` constants to `troubleshoot/routes.py`; rewrite all `yield` statements in `ping_stream` to use these helpers (eliminates raw `data: ...\n\n` strings)

## Test plan

- [x] `ENV_FOR_DYNACONF=testing python -m pytest` — 66 passed
- [ ] Verify ping page renders with correct default values (count=5, timeout=2, data_size=100)
- [ ] Verify ping SSE stream still works end-to-end