### PR TITLE
refactor(tests): rename cmd/cmds to command/commands for consistency

### DIFF
--- a/tests/test_troubleshoot_command_builder.py
+++ b/tests/test_troubleshoot_command_builder.py
@@ -53,21 +53,21 @@ class TestCiscoIOSTroubleshootBuilder:
     builder = CiscoIOSTroubleshootBuilder()
 
     def test_full_options(self):
-        cmd = self.builder.build_ping(DST, SRC, VRF, COUNT, TIMEOUT, SIZE)
-        assert cmd == "ping vrf MGMT 10.0.0.1 source 192.168.1.1 repeat 5 timeout 2 size 100"
+        command = self.builder.build_ping(DST, SRC, VRF, COUNT, TIMEOUT, SIZE)
+        assert command == "ping vrf MGMT 10.0.0.1 source 192.168.1.1 repeat 5 timeout 2 size 100"
 
     def test_no_vrf(self):
-        cmd = self.builder.build_ping(DST, SRC, None, COUNT, TIMEOUT, SIZE)
-        assert "vrf" not in cmd
-        assert cmd.startswith("ping 10.0.0.1")
+        command = self.builder.build_ping(DST, SRC, None, COUNT, TIMEOUT, SIZE)
+        assert "vrf" not in command
+        assert command.startswith("ping 10.0.0.1")
 
     def test_no_src_ip(self):
-        cmd = self.builder.build_ping(DST, None, VRF, COUNT, TIMEOUT, SIZE)
-        assert "source" not in cmd
+        command = self.builder.build_ping(DST, None, VRF, COUNT, TIMEOUT, SIZE)
+        assert "source" not in command
 
     def test_minimal(self):
-        cmd = self.builder.build_ping(DST, None, None, COUNT, TIMEOUT, SIZE)
-        assert cmd == "ping 10.0.0.1 repeat 5 timeout 2 size 100"
+        command = self.builder.build_ping(DST, None, None, COUNT, TIMEOUT, SIZE)
+        assert command == "ping 10.0.0.1 repeat 5 timeout 2 size 100"
 
     def test_returns_str(self):
         assert isinstance(self.builder.build_ping(DST, SRC, VRF, COUNT, TIMEOUT, SIZE), str)
@@ -79,21 +79,21 @@ class TestCiscoNXOSTroubleshootBuilder:
     builder = CiscoNXOSTroubleshootBuilder()
 
     def test_full_options(self):
-        cmd = self.builder.build_ping(DST, SRC, VRF, COUNT, TIMEOUT, SIZE)
-        assert "ping 10.0.0.1" in cmd
-        assert "count 5" in cmd
-        assert "source 192.168.1.1" in cmd
-        assert "vrf MGMT" in cmd
-        assert "packet-size 100" in cmd
-        assert "timeout 2" in cmd
+        command = self.builder.build_ping(DST, SRC, VRF, COUNT, TIMEOUT, SIZE)
+        assert "ping 10.0.0.1" in command
+        assert "count 5" in command
+        assert "source 192.168.1.1" in command
+        assert "vrf MGMT" in command
+        assert "packet-size 100" in command
+        assert "timeout 2" in command
 
     def test_no_vrf(self):
-        cmd = self.builder.build_ping(DST, SRC, None, COUNT, TIMEOUT, SIZE)
-        assert "vrf" not in cmd
+        command = self.builder.build_ping(DST, SRC, None, COUNT, TIMEOUT, SIZE)
+        assert "vrf" not in command
 
     def test_no_src_ip(self):
-        cmd = self.builder.build_ping(DST, None, VRF, COUNT, TIMEOUT, SIZE)
-        assert "source" not in cmd
+        command = self.builder.build_ping(DST, None, VRF, COUNT, TIMEOUT, SIZE)
+        assert "source" not in command
 
 
 # ── Cisco IOS-XR ─────────────────────────────────────────────────────
@@ -102,13 +102,13 @@ class TestCiscoXRTroubleshootBuilder:
     builder = CiscoXRTroubleshootBuilder()
 
     def test_full_options(self):
-        cmd = self.builder.build_ping(DST, SRC, VRF, COUNT, TIMEOUT, SIZE)
-        assert cmd == "ping vrf MGMT 10.0.0.1 source 192.168.1.1 count 5 timeout 2 size 100"
+        command = self.builder.build_ping(DST, SRC, VRF, COUNT, TIMEOUT, SIZE)
+        assert command == "ping vrf MGMT 10.0.0.1 source 192.168.1.1 count 5 timeout 2 size 100"
 
     def test_no_vrf(self):
-        cmd = self.builder.build_ping(DST, SRC, None, COUNT, TIMEOUT, SIZE)
-        assert cmd.startswith("ping 10.0.0.1")
-        assert "vrf" not in cmd
+        command = self.builder.build_ping(DST, SRC, None, COUNT, TIMEOUT, SIZE)
+        assert command.startswith("ping 10.0.0.1")
+        assert "vrf" not in command
 
 
 # ── Arista EOS ───────────────────────────────────────────────────────
@@ -117,13 +117,13 @@ class TestAristaEOSTroubleshootBuilder:
     builder = AristaEOSTroubleshootBuilder()
 
     def test_full_options(self):
-        cmd = self.builder.build_ping(DST, SRC, VRF, COUNT, TIMEOUT, SIZE)
-        assert cmd == "ping 10.0.0.1 source 192.168.1.1 repeat 5 size 100 vrf MGMT"
+        command = self.builder.build_ping(DST, SRC, VRF, COUNT, TIMEOUT, SIZE)
+        assert command == "ping 10.0.0.1 source 192.168.1.1 repeat 5 size 100 vrf MGMT"
 
     def test_no_vrf(self):
-        cmd = self.builder.build_ping(DST, SRC, None, COUNT, TIMEOUT, SIZE)
-        assert "vrf" not in cmd
-        assert cmd.endswith(f"size {SIZE}")
+        command = self.builder.build_ping(DST, SRC, None, COUNT, TIMEOUT, SIZE)
+        assert "vrf" not in command
+        assert command.endswith(f"size {SIZE}")
 
 
 # ── Juniper JunOS ────────────────────────────────────────────────────
@@ -132,22 +132,22 @@ class TestJuniperJunOSTroubleshootBuilder:
     builder = JuniperJunOSTroubleshootBuilder()
 
     def test_full_options(self):
-        cmd = self.builder.build_ping(DST, SRC, VRF, COUNT, TIMEOUT, SIZE)
-        assert "ping 10.0.0.1" in cmd
-        assert "count 5" in cmd
-        assert "source 192.168.1.1" in cmd
-        assert "routing-instance MGMT" in cmd   # VRF キーワードが異なる
-        assert "size 100" in cmd
-        assert "wait 2" in cmd
+        command = self.builder.build_ping(DST, SRC, VRF, COUNT, TIMEOUT, SIZE)
+        assert "ping 10.0.0.1" in command
+        assert "count 5" in command
+        assert "source 192.168.1.1" in command
+        assert "routing-instance MGMT" in command   # VRF キーワードが異なる
+        assert "size 100" in command
+        assert "wait 2" in command
 
     def test_vrf_keyword_is_routing_instance(self):
-        cmd = self.builder.build_ping(DST, None, VRF, COUNT, TIMEOUT, SIZE)
-        assert "routing-instance MGMT" in cmd
-        assert "vrf" not in cmd
+        command = self.builder.build_ping(DST, None, VRF, COUNT, TIMEOUT, SIZE)
+        assert "routing-instance MGMT" in command
+        assert "vrf" not in command
 
     def test_no_vrf(self):
-        cmd = self.builder.build_ping(DST, SRC, None, COUNT, TIMEOUT, SIZE)
-        assert "routing-instance" not in cmd
+        command = self.builder.build_ping(DST, SRC, None, COUNT, TIMEOUT, SIZE)
+        assert "routing-instance" not in command
 
 
 # ── Palo Alto PAN-OS ─────────────────────────────────────────────────
@@ -156,13 +156,13 @@ class TestPaloAltoTroubleshootBuilder:
     builder = PaloAltoTroubleshootBuilder()
 
     def test_full_options(self):
-        cmd = self.builder.build_ping(DST, SRC, VRF, COUNT, TIMEOUT, SIZE)
-        assert cmd == "ping vrouter MGMT host 10.0.0.1 source 192.168.1.1 count 5"
+        command = self.builder.build_ping(DST, SRC, VRF, COUNT, TIMEOUT, SIZE)
+        assert command == "ping vrouter MGMT host 10.0.0.1 source 192.168.1.1 count 5"
 
     def test_no_vrf(self):
-        cmd = self.builder.build_ping(DST, SRC, None, COUNT, TIMEOUT, SIZE)
-        assert "vrouter" not in cmd
-        assert cmd.startswith("ping host")
+        command = self.builder.build_ping(DST, SRC, None, COUNT, TIMEOUT, SIZE)
+        assert "vrouter" not in command
+        assert command.startswith("ping host")
 
 
 # ── Cisco ASA ────────────────────────────────────────────────────────
@@ -171,14 +171,14 @@ class TestCiscoASATroubleshootBuilder:
     builder = CiscoASATroubleshootBuilder()
 
     def test_basic_ping(self):
-        cmd = self.builder.build_ping(DST, SRC, VRF, COUNT, TIMEOUT, SIZE)
-        assert cmd == "ping 10.0.0.1"
+        command = self.builder.build_ping(DST, SRC, VRF, COUNT, TIMEOUT, SIZE)
+        assert command == "ping 10.0.0.1"
 
     def test_src_and_vrf_ignored(self):
         # ASA は source / VRF を無視する
-        cmd_with = self.builder.build_ping(DST, SRC, VRF, COUNT, TIMEOUT, SIZE)
-        cmd_without = self.builder.build_ping(DST, None, None, COUNT, TIMEOUT, SIZE)
-        assert cmd_with == cmd_without
+        command_with = self.builder.build_ping(DST, SRC, VRF, COUNT, TIMEOUT, SIZE)
+        command_without = self.builder.build_ping(DST, None, None, COUNT, TIMEOUT, SIZE)
+        assert command_with == command_without
 
 
 # ── Fortinet FortiOS ─────────────────────────────────────────────────
@@ -187,24 +187,24 @@ class TestFortinetTroubleshootBuilder:
     builder = FortinetTroubleshootBuilder()
 
     def test_returns_list(self):
-        result = self.builder.build_ping(DST, SRC, VRF, COUNT, TIMEOUT, SIZE)
-        assert isinstance(result, list)
+        commands = self.builder.build_ping(DST, SRC, VRF, COUNT, TIMEOUT, SIZE)
+        assert isinstance(commands, list)
 
     def test_full_options(self):
-        cmds = self.builder.build_ping(DST, SRC, VRF, COUNT, TIMEOUT, SIZE)
-        assert any("ping-options source 192.168.1.1" in c for c in cmds)
-        assert any("ping-options count 5" in c for c in cmds)
-        assert any("ping-options timeout 2" in c for c in cmds)
-        assert any("ping-options data-size 100" in c for c in cmds)
-        assert cmds[-1] == "execute ping 10.0.0.1"
+        commands = self.builder.build_ping(DST, SRC, VRF, COUNT, TIMEOUT, SIZE)
+        assert any("ping-options source 192.168.1.1" in c for c in commands)
+        assert any("ping-options count 5" in c for c in commands)
+        assert any("ping-options timeout 2" in c for c in commands)
+        assert any("ping-options data-size 100" in c for c in commands)
+        assert commands[-1] == "execute ping 10.0.0.1"
 
     def test_no_src_ip_skips_source_option(self):
-        cmds = self.builder.build_ping(DST, None, VRF, COUNT, TIMEOUT, SIZE)
-        assert not any("ping-options source" in c for c in cmds)
+        commands = self.builder.build_ping(DST, None, VRF, COUNT, TIMEOUT, SIZE)
+        assert not any("ping-options source" in c for c in commands)
 
     def test_last_command_is_execute_ping(self):
-        cmds = self.builder.build_ping(DST, SRC, None, COUNT, TIMEOUT, SIZE)
-        assert cmds[-1] == f"execute ping {DST}"
+        commands = self.builder.build_ping(DST, SRC, None, COUNT, TIMEOUT, SIZE)
+        assert commands[-1] == f"execute ping {DST}"
 
 
 # ── build_traceroute / build_telnet は NotImplementedError ──────────


### PR DESCRIPTION
## Summary

- `cmd` → `command` across all ping test methods
- `cmds` → `commands` in Fortinet ping tests
- `cmd_with` / `cmd_without` → `command_with` / `command_without` in ASA tests
- `result` → `commands` in Fortinet `test_returns_list`

routes.py では `command`/`commands` を使っているため、テストファイルも統一。

## Test plan

- [ ] `ENV_FOR_DYNACONF=testing python -m pytest tests/test_troubleshoot_command_builder.py` が全テスト通過すること