### PR TITLE
feat: add Traceroute feature with real-time SSE streaming

### DIFF
--- a/neteye/base/templates/base_template.html
+++ b/neteye/base/templates/base_template.html
@@ -122,7 +122,9 @@
                         <li class="nav-item">
                             <a class="nav-link" href="/troubleshoot/ping">Ping</a>
                         </li>
-                        {# Traceroute hidden until implemented #}
+                        <li class="nav-item">
+                            <a class="nav-link" href="/troubleshoot/traceroute">Traceroute</a>
+                        </li>
                     </ul>
                 </li>
                 <li class="nav-item nav-dropdown">

--- a/neteye/lib/troubleshoot_command_builder.py
+++ b/neteye/lib/troubleshoot_command_builder.py
@@ -2,11 +2,12 @@
 
 Device-specific troubleshoot command builders.
 
-Each device type has a corresponding subclass that implements build_ping().
-build_traceroute() and build_telnet() are planned for future releases.
+Each device type has a corresponding subclass that implements build_ping()
+and build_traceroute(). build_telnet() is planned for future releases.
 
 To add support for a new device type:
-  1. Create a subclass of TroubleshootBuilder and implement build_ping().
+  1. Create a subclass of TroubleshootBuilder and implement build_ping()
+     and build_traceroute().
   2. Add one entry to _BUILDER_REGISTRY.
   3. Add test cases to tests/test_troubleshoot_command_builder.py.
   No changes to callers (routes.py etc.) are required.
@@ -23,10 +24,9 @@ class UnsupportedDeviceTypeError(Exception):
 class TroubleshootBuilder(ABC):
     """Abstract base class for device-specific troubleshoot command builders.
 
-    Subclasses must implement build_ping().
-    build_traceroute() and build_telnet() raise NotImplementedError until implemented.
-    The helper methods _vrf_part() and _src_part() are shared across ping, traceroute,
-    and telnet commands.
+    Subclasses must implement build_ping() and build_traceroute().
+    build_telnet() raises NotImplementedError until implemented.
+    The helper method _optional() is shared across ping, traceroute, and telnet commands.
     """
 
     @abstractmethod
@@ -42,18 +42,23 @@ class TroubleshootBuilder(ABC):
         """Return the ping command string, or a list of strings for multi-step devices."""
         ...
 
+    @abstractmethod
     def build_traceroute(
         self,
         dst_ip: str,
         src_ip: str | None,
         vrf: str | None,
-        count: int,
+        probe: int,
         timeout: int,
-        size: int,
+        max_ttl: int,
     ) -> str | list[str]:
-        raise NotImplementedError(
-            f"traceroute is not yet implemented for {type(self).__name__}"
-        )
+        """Return the traceroute command string, or a list of strings for multi-step devices.
+
+        Args:
+            probe: Number of probes per hop (sent per TTL value).
+            max_ttl: Maximum TTL (controls the maximum number of hops).
+        """
+        ...
 
     def build_telnet(
         self,
@@ -68,13 +73,14 @@ class TroubleshootBuilder(ABC):
 
     # ── Shared helpers ───────────────────────────────────────────────
 
-    def _vrf_part(self, keyword: str, vrf: str | None) -> str:
-        """Return 'keyword vrf ' (trailing space) when vrf is given, else empty string."""
-        return f"{keyword} {vrf} " if vrf else ""
+    def _optional(self, keyword: str, value: str | None) -> list[str]:
+        """Return ['{keyword} {value}'] when value is given, else [].
 
-    def _src_part(self, keyword: str, src_ip: str | None) -> str:
-        """Return ' keyword src_ip' (leading space) when src_ip is given, else empty string."""
-        return f" {keyword} {src_ip}" if src_ip else ""
+        Use with += to conditionally append a keyword-value pair to a command list:
+            command += self._optional("vrf", vrf)
+        """
+        return [f"{keyword} {value}"] if value else []
+
 
 
 # ── Device-specific builders ─────────────────────────────────────────
@@ -84,84 +90,149 @@ class CiscoIOSTroubleshootBuilder(TroubleshootBuilder):
     """Cisco IOS / IOS-XE (shared — identical syntax)."""
 
     def build_ping(self, dst_ip, src_ip, vrf, count, timeout, size) -> str:
-        # ping [vrf <vrf>] <dst> [source <src>] [repeat <n>] [timeout <n>] [size <n>]
-        vrf_part = self._vrf_part("vrf", vrf)
-        src_part = self._src_part("source", src_ip)
-        return (
-            f"ping {vrf_part}{dst_ip}{src_part}"
-            f" repeat {count} timeout {timeout} size {size}"
-        )
+        # ping [vrf VRF] DST [source SRC] repeat N timeout N size N
+        command  = ["ping"]
+        command += self._optional("vrf", vrf)
+        command += [dst_ip]
+        command += self._optional("source", src_ip)
+        command += [f"repeat {count}"]
+        command += [f"timeout {timeout}"]
+        command += [f"size {size}"]
+        return " ".join(command)
+
+    def build_traceroute(self, dst_ip, src_ip, vrf, probe, timeout, max_ttl) -> str:
+        # traceroute [vrf VRF] DST [source SRC] probe N timeout N ttl 1 N
+        command  = ["traceroute"]
+        command += self._optional("vrf", vrf)
+        command += [dst_ip]
+        command += self._optional("source", src_ip)
+        command += [f"probe {probe}"]
+        command += [f"timeout {timeout}"]
+        command += [f"ttl 1 {max_ttl}"]
+        return " ".join(command)
 
 
 class CiscoNXOSTroubleshootBuilder(TroubleshootBuilder):
     """Cisco NX-OS."""
 
     def build_ping(self, dst_ip, src_ip, vrf, count, timeout, size) -> str:
-        # ping <dst> [count <n>] [source <src>] [vrf <vrf>] [packet-size <n>] [timeout <n>]
-        parts = [f"ping {dst_ip}", f"count {count}"]
-        if src_ip:
-            parts.append(f"source {src_ip}")
-        if vrf:
-            parts.append(f"vrf {vrf}")
-        parts.append(f"packet-size {size}")
-        parts.append(f"timeout {timeout}")
-        return " ".join(parts)
+        # ping DST count N [source SRC] [vrf VRF] packet-size N timeout N
+        command  = ["ping"]
+        command += [dst_ip]
+        command += [f"count {count}"]
+        command += self._optional("source", src_ip)
+        command += self._optional("vrf", vrf)
+        command += [f"packet-size {size}"]
+        command += [f"timeout {timeout}"]
+        return " ".join(command)
+
+    def build_traceroute(self, dst_ip, src_ip, vrf, probe, timeout, max_ttl) -> str:
+        # traceroute DST [source SRC] [vrf VRF] probe N timeout N
+        # NX-OS does not support a max-ttl option (max_ttl is ignored)
+        command  = ["traceroute"]
+        command += [dst_ip]
+        command += self._optional("source", src_ip)
+        command += self._optional("vrf", vrf)
+        command += [f"probe {probe}"]
+        command += [f"timeout {timeout}"]
+        return " ".join(command)
 
 
 class CiscoXRTroubleshootBuilder(TroubleshootBuilder):
     """Cisco IOS-XR."""
 
     def build_ping(self, dst_ip, src_ip, vrf, count, timeout, size) -> str:
-        # ping [vrf <vrf>] <dst> [source <src>] [count <n>] [timeout <n>] [size <n>]
-        vrf_part = self._vrf_part("vrf", vrf)
-        src_part = self._src_part("source", src_ip)
-        return (
-            f"ping {vrf_part}{dst_ip}{src_part}"
-            f" count {count} timeout {timeout} size {size}"
-        )
+        # ping [vrf VRF] DST [source SRC] count N timeout N size N
+        command  = ["ping"]
+        command += self._optional("vrf", vrf)
+        command += [dst_ip]
+        command += self._optional("source", src_ip)
+        command += [f"count {count}"]
+        command += [f"timeout {timeout}"]
+        command += [f"size {size}"]
+        return " ".join(command)
+
+    def build_traceroute(self, dst_ip, src_ip, vrf, probe, timeout, max_ttl) -> str:
+        # traceroute [vrf VRF] DST [source SRC] probe N timeout N max-ttl N
+        command  = ["traceroute"]
+        command += self._optional("vrf", vrf)
+        command += [dst_ip]
+        command += self._optional("source", src_ip)
+        command += [f"probe {probe}"]
+        command += [f"timeout {timeout}"]
+        command += [f"max-ttl {max_ttl}"]
+        return " ".join(command)
 
 
 class AristaEOSTroubleshootBuilder(TroubleshootBuilder):
     """Arista EOS."""
 
     def build_ping(self, dst_ip, src_ip, vrf, count, timeout, size) -> str:
-        # ping <dst> [source <src>] [repeat <n>] [size <n>] [vrf <vrf>]
-        parts = [f"ping {dst_ip}"]
-        if src_ip:
-            parts.append(f"source {src_ip}")
-        parts.append(f"repeat {count}")
-        parts.append(f"size {size}")
-        if vrf:
-            parts.append(f"vrf {vrf}")
-        return " ".join(parts)
+        # ping DST [source SRC] repeat N size N [vrf VRF]
+        command  = ["ping"]
+        command += [dst_ip]
+        command += self._optional("source", src_ip)
+        command += [f"repeat {count}"]
+        command += [f"size {size}"]
+        command += self._optional("vrf", vrf)
+        return " ".join(command)
+
+    def build_traceroute(self, dst_ip, src_ip, vrf, probe, timeout, max_ttl) -> str:
+        # traceroute DST [source SRC] probe N maxttl N
+        # Arista does not support a timeout option (timeout is ignored)
+        command  = ["traceroute"]
+        command += [dst_ip]
+        command += self._optional("source", src_ip)
+        command += [f"probe {probe}"]
+        command += [f"maxttl {max_ttl}"]
+        return " ".join(command)
 
 
 class JuniperJunOSTroubleshootBuilder(TroubleshootBuilder):
     """Juniper JunOS. VRF keyword is 'routing-instance' (differs from other vendors)."""
 
     def build_ping(self, dst_ip, src_ip, vrf, count, timeout, size) -> str:
-        # ping <dst> [count <n>] [source <src>] [routing-instance <vrf>] [size <n>] [wait <n>]
-        src_part = self._src_part("source", src_ip)
-        ri_part = self._vrf_part("routing-instance", vrf)
-        return (
-            f"ping {dst_ip} count {count}{src_part}"
-            f" {ri_part}size {size} wait {timeout}"
-        ).strip()
+        # ping DST count N [source SRC] [routing-instance VRF] size N wait N
+        command  = ["ping"]
+        command += [dst_ip]
+        command += [f"count {count}"]
+        command += self._optional("source", src_ip)
+        command += self._optional("routing-instance", vrf)
+        command += [f"size {size}"]
+        command += [f"wait {timeout}"]
+        return " ".join(command)
+
+    def build_traceroute(self, dst_ip, src_ip, vrf, probe, timeout, max_ttl) -> str:
+        # traceroute DST [source SRC] [routing-instance VRF] probe-count N wait N ttl N
+        command  = ["traceroute"]
+        command += [dst_ip]
+        command += self._optional("source", src_ip)
+        command += self._optional("routing-instance", vrf)
+        command += [f"probe-count {probe}"]
+        command += [f"wait {timeout}"]
+        command += [f"ttl {max_ttl}"]
+        return " ".join(command)
 
 
 class PaloAltoTroubleshootBuilder(TroubleshootBuilder):
     """Palo Alto PAN-OS. VRF equivalent is 'vrouter'."""
 
     def build_ping(self, dst_ip, src_ip, vrf, count, timeout, size) -> str:
-        # ping [vrouter <vrf>] host <dst> [source <src>] [count <n>]
-        parts = ["ping"]
-        if vrf:
-            parts.append(f"vrouter {vrf}")
-        parts.append(f"host {dst_ip}")
-        if src_ip:
-            parts.append(f"source {src_ip}")
-        parts.append(f"count {count}")
-        return " ".join(parts)
+        # ping [vrouter VRF] host DST [source SRC] count N
+        command  = ["ping"]
+        command += self._optional("vrouter", vrf)
+        command += ["host", dst_ip]
+        command += self._optional("source", src_ip)
+        command += [f"count {count}"]
+        return " ".join(command)
+
+    def build_traceroute(self, dst_ip, src_ip, vrf, probe, timeout, max_ttl) -> str:
+        # traceroute host DST [source SRC]
+        # vrouter/probe/timeout/max_ttl are not supported for traceroute on PAN-OS
+        command  = ["traceroute", "host"]
+        command += [dst_ip]
+        command += self._optional("source", src_ip)
+        return " ".join(command)
 
 
 class CiscoASATroubleshootBuilder(TroubleshootBuilder):
@@ -171,9 +242,13 @@ class CiscoASATroubleshootBuilder(TroubleshootBuilder):
         # ping <dst>
         return f"ping {dst_ip}"
 
+    def build_traceroute(self, dst_ip, src_ip, vrf, probe, timeout, max_ttl) -> str:
+        # traceroute DST (src/vrf/probe/timeout/ttl not supported)
+        return f"traceroute {dst_ip}"
+
 
 class FortinetTroubleshootBuilder(TroubleshootBuilder):
-    """Fortinet FortiOS. Returns a list of commands (multi-step). VRF not supported."""
+    """Fortinet FortiOS. Returns a list of commands (multi-step) for ping. VRF not supported."""
 
     def build_ping(self, dst_ip, src_ip, vrf, count, timeout, size) -> list[str]:
         # Configure options with 'execute ping-options', then run 'execute ping'
@@ -185,6 +260,10 @@ class FortinetTroubleshootBuilder(TroubleshootBuilder):
         commands.append(f"execute ping-options data-size {size}")
         commands.append(f"execute ping {dst_ip}")
         return commands
+
+    def build_traceroute(self, dst_ip, src_ip, vrf, probe, timeout, max_ttl) -> str:
+        # execute traceroute DST (single command; src/vrf/probe/timeout not supported)
+        return f"execute traceroute {dst_ip}"
 
 
 # ── Factory ──────────────────────────────────────────────────────────

--- a/neteye/troubleshoot/forms.py
+++ b/neteye/troubleshoot/forms.py
@@ -44,3 +44,39 @@ class PingForm(FlaskForm):
     )
     submit = SubmitField("Submit")
     reset = SubmitField("Reset")
+
+
+# Traceroute form defaults
+TRACEROUTE_MAX_PROBE       = 10
+TRACEROUTE_DEFAULT_MAX_TTL = 30
+TRACEROUTE_DEFAULT_PROBE   = 3
+TRACEROUTE_DEFAULT_TIMEOUT = 3
+
+
+class TracerouteForm(FlaskForm):
+    dst_ip_address = StringField("Destination IP Address:", validators=[DataRequired()])
+    src_node = QuerySelectField(
+        "Source Node:",
+        validators=[DataRequired()],
+        query_factory=get_nodes,
+        get_label="hostname",
+    )
+    src_ip_address = SelectField("Source IP Address:", choices=[], validators=[Optional()])
+    vrf = StringField("VRF:", validators=[Optional()])
+    max_ttl = IntegerField(
+        "Max TTL:",
+        validators=[DataRequired(), NumberRange(min=1, max=settings.TRACEROUTE_MAX_TTL)],
+        default=TRACEROUTE_DEFAULT_MAX_TTL,
+    )
+    probe = IntegerField(
+        "Probe:",
+        validators=[DataRequired(), NumberRange(min=1, max=TRACEROUTE_MAX_PROBE)],
+        default=TRACEROUTE_DEFAULT_PROBE,
+    )
+    timeout = IntegerField(
+        "Timeout:",
+        validators=[DataRequired(), NumberRange(min=1, max=settings.TRACEROUTE_MAX_TIMEOUT)],
+        default=TRACEROUTE_DEFAULT_TIMEOUT,
+    )
+    submit = SubmitField("Submit")
+    reset = SubmitField("Reset")

--- a/neteye/troubleshoot/routes.py
+++ b/neteye/troubleshoot/routes.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 import time
 
 from flask import Response, flash, render_template, request, stream_with_context
@@ -17,7 +18,17 @@ from neteye.lib.troubleshoot_command_builder import (
 from neteye.lib.utils.report_exception import report_exception
 from neteye.node.models import Node
 
-from .forms import PING_DEFAULT_COUNT, PING_DEFAULT_DATA_SIZE, PING_DEFAULT_TIMEOUT, PingForm
+from .forms import (
+    PING_DEFAULT_COUNT,
+    PING_DEFAULT_DATA_SIZE,
+    PING_DEFAULT_TIMEOUT,
+    TRACEROUTE_DEFAULT_MAX_TTL,
+    TRACEROUTE_DEFAULT_PROBE,
+    TRACEROUTE_DEFAULT_TIMEOUT,
+    TRACEROUTE_MAX_PROBE,
+    PingForm,
+    TracerouteForm,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +63,23 @@ def _annotate_ip(ip_address: str) -> str | None:
         return f"{iface.node.hostname} ({iface.name})"
 
     return None
+
+
+_IP_RE = re.compile(r'\b(\d{1,3}(?:\.\d{1,3}){3})\b')
+
+
+def _annotate_traceroute_line(line: str) -> str:
+    """Annotate IPv4 addresses in a traceroute hop line with Node/Interface DB lookups.
+
+    Each IPv4 address found in the line is looked up via _annotate_ip().
+    If a match is found, the annotation is appended in brackets:
+      192.168.1.1  ->  192.168.1.1 [router1 (Gi0/0)]
+    """
+    def _replace(match: re.Match) -> str:
+        ip = match.group(1)
+        annotation = _annotate_ip(ip)
+        return f"{ip} [{annotation}]" if annotation else ip
+    return _IP_RE.sub(_replace, line)
 
 
 @troubleshoot_bp.route("/ping")
@@ -257,6 +285,141 @@ def ping_stream():
                 ).add()
             except Exception as err:
                 logger.warning("Failed to record ping to history: %s", err)
+            try:
+                conn.disconnect()
+            except Exception:
+                pass
+
+        yield _SSE_DONE
+
+    return Response(
+        stream_with_context(generate()),
+        mimetype="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+@troubleshoot_bp.route("/traceroute")
+@auth_required()
+def traceroute():
+    form = TracerouteForm()
+    return render_template("/troubleshoot/traceroute.html", form=form)
+
+
+@troubleshoot_bp.route("/traceroute/stream")
+@auth_required()
+def traceroute_stream():
+    """SSE endpoint for real-time traceroute output."""
+    node_id = request.args.get("node_id", "").strip()
+    dst_ip  = request.args.get("dst_ip", "").strip()
+    src_ip  = request.args.get("src_ip", "").strip() or None
+    vrf     = request.args.get("vrf", "").strip() or None
+    max_ttl = min(max(request.args.get("max_ttl", TRACEROUTE_DEFAULT_MAX_TTL, type=int), 1), settings.TRACEROUTE_MAX_TTL)
+    probe   = min(max(request.args.get("probe",   TRACEROUTE_DEFAULT_PROBE,   type=int), 1), TRACEROUTE_MAX_PROBE)
+    timeout = min(max(request.args.get("timeout", TRACEROUTE_DEFAULT_TIMEOUT, type=int), 1), settings.TRACEROUTE_MAX_TIMEOUT)
+
+    node = Node.query.filter_by(id=node_id).first() if node_id else None
+
+    def generate():
+        # --- Validation ---
+        if not node:
+            yield _sse_message("ERROR: Node not found")
+            yield _SSE_DONE
+            return
+        if not dst_ip:
+            yield _sse_message("ERROR: Destination IP is required")
+            yield _SSE_DONE
+            return
+
+        # --- Build command ---
+        try:
+            builder = get_troubleshoot_builder(node.device_type)
+            command = builder.build_traceroute(
+                dst_ip=dst_ip,
+                src_ip=src_ip,
+                vrf=vrf,
+                probe=probe,
+                timeout=timeout,
+                max_ttl=max_ttl,
+            )
+        except (UnsupportedDeviceTypeError, NotImplementedError):
+            yield _sse_message(f"ERROR: Traceroute is not supported for device type: {node.device_type}")
+            yield _SSE_DONE
+            return
+
+        commands = command if isinstance(command, list) else [command]
+        commands_str = "\n".join(commands)
+
+        # --- Emit header info ---
+        dst_annotation = _annotate_ip(dst_ip)
+        annotation_suffix = f" -> {dst_annotation}" if dst_annotation else ""
+        yield _sse_message(f"Destination : {dst_ip}{annotation_suffix}")
+        yield _sse_message(f"Command     : {commands_str}")
+        yield _SSE_SEPARATOR
+
+        # --- Open dedicated connection ---
+        try:
+            conn = node.gen_netmiko_connection()
+        except Exception as err:
+            report_exception(err, "Traceroute connection failed")
+            yield _sse_message(f"ERROR: Connection failed: {err}")
+            yield _SSE_DONE
+            return
+
+        # --- Stream output ---
+        output_lines: list[str] = []
+        try:
+            prompt = conn.find_prompt()
+            # Traceroute can take up to max_ttl * timeout seconds
+            deadline = time.time() + max_ttl * timeout + 60
+
+            for command in commands:
+                conn.write_channel(command + "\n")
+                time.sleep(0.2)
+
+                buffer = ""
+                while time.time() < deadline:
+                    chunk = conn.read_channel()
+                    if chunk:
+                        buffer += chunk
+                        for line in chunk.splitlines():
+                            if line.strip():
+                                output_lines.append(line)
+                                yield _sse_message(_annotate_traceroute_line(line))
+                        if prompt in buffer:
+                            break
+                    else:
+                        time.sleep(0.3)
+
+            history_result = "\n".join(output_lines)
+
+        except GeneratorExit:
+            history_result = "\n".join(output_lines) + "\n(cancelled)"
+            interrupt_char = get_interrupt_char(node.device_type)
+            try:
+                conn.write_channel(interrupt_char)
+                time.sleep(0.2)
+            except Exception:
+                pass
+            raise
+
+        except Exception as err:
+            history_result = "\n".join(output_lines) + "\n(error)"
+            report_exception(err, "Traceroute execution failed")
+            yield _sse_message(f"ERROR: {err}")
+
+        finally:
+            # --- Record to CommandHistory (always — including cancel and error) ---
+            try:
+                CommandHistory(
+                    username=current_user.email,
+                    node_id=node.id,
+                    hostname=node.hostname,
+                    command=commands_str,
+                    result=json.dumps(history_result),
+                ).add()
+            except Exception as err:
+                logger.warning("Failed to record traceroute to history: %s", err)
             try:
                 conn.disconnect()
             except Exception:

--- a/neteye/troubleshoot/routes.py
+++ b/neteye/troubleshoot/routes.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import time
 
@@ -111,19 +112,15 @@ def ping_execute():
     # Use netmiko_raw_command directly: scrapli's timeout_transport is fixed at
     # connection creation and cannot be overridden per-command, causing EOF errors
     # on long-running commands. netmiko's read_timeout works correctly per-command.
+    commands = command if isinstance(command, list) else [command]
+    commands_str = "\n".join(commands)
     read_timeout = count * timeout + 10
     try:
-        if isinstance(command, list):
-            # Multi-step command (e.g. Fortinet): run each step and join the output.
-            outputs = [
-                node.netmiko_raw_command(cmd, current_user.email, timeout=read_timeout)
-                for cmd in command
-            ]
-            result = "\n".join(filter(None, outputs))
-            command_str = "\n".join(command)
-        else:
-            result = node.netmiko_raw_command(command, current_user.email, timeout=read_timeout)
-            command_str = command
+        outputs = [
+            node.netmiko_raw_command(step, current_user.email, timeout=read_timeout)
+            for step in commands
+        ]
+        result = "\n".join(filter(None, outputs))
     except Exception as err:
         report_exception(err, "Ping execution failed")
         return render_template("/troubleshoot/ping.html", form=form)
@@ -135,7 +132,7 @@ def ping_execute():
         "/troubleshoot/ping.html",
         form=form,
         result=result,
-        command=command_str,
+        command=commands_str,
         dst_ip=dst_ip,
         dst_annotation=dst_annotation,
     )
@@ -188,13 +185,13 @@ def ping_stream():
             return
 
         commands = command if isinstance(command, list) else [command]
-        command_str = "\n".join(commands) if isinstance(command, list) else command
+        commands_str = "\n".join(commands)
 
         # --- Emit header info ---
         dst_annotation = _annotate_ip(dst_ip)
         annotation_suffix = f" -> {dst_annotation}" if dst_annotation else ""
         yield _sse_message(f"Destination : {dst_ip}{annotation_suffix}")
-        yield _sse_message(f"Command     : {command_str}")
+        yield _sse_message(f"Command     : {commands_str}")
         yield _SSE_SEPARATOR
 
         # --- Open dedicated connection (not from pool) ---
@@ -207,12 +204,13 @@ def ping_stream():
             return
 
         # --- Stream output ---
+        output_lines: list[str] = []
         try:
             prompt = conn.find_prompt()
             deadline = time.time() + count * timeout + 30
 
-            for cmd in commands:
-                conn.write_channel(cmd + "\n")
+            for command in commands:
+                conn.write_channel(command + "\n")
                 time.sleep(0.2)
 
                 buffer = ""
@@ -222,26 +220,18 @@ def ping_stream():
                         buffer += chunk
                         for line in chunk.splitlines():
                             if line.strip():
+                                output_lines.append(line)
                                 yield _sse_message(line)
                         if prompt in buffer:
                             break
                     else:
                         time.sleep(0.3)
 
-            # --- Record to CommandHistory (normal completion only) ---
-            try:
-                CommandHistory(
-                    username=current_user.email,
-                    node_id=node.id,
-                    hostname=node.hostname,
-                    command=command_str,
-                    result="(streamed via SSE)",
-                ).add()
-            except Exception as err:
-                logger.warning("Failed to record ping to history: %s", err)
+            history_result = "\n".join(output_lines)
 
         except GeneratorExit:
             # Client cancelled the stream — send device-specific interrupt to stop the ping.
+            history_result = "\n".join(output_lines) + "\n(cancelled)"
             interrupt_char = get_interrupt_char(node.device_type)
             try:
                 conn.write_channel(interrupt_char)
@@ -251,9 +241,22 @@ def ping_stream():
             raise   # Re-raise so the generator exits cleanly.
 
         except Exception as err:
+            history_result = "\n".join(output_lines) + "\n(error)"
             report_exception(err, "Ping execution failed")
             yield _sse_message(f"ERROR: {err}")
+
         finally:
+            # --- Record to CommandHistory (always — including cancel and error) ---
+            try:
+                CommandHistory(
+                    username=current_user.email,
+                    node_id=node.id,
+                    hostname=node.hostname,
+                    command=commands_str,
+                    result=json.dumps(history_result),
+                ).add()
+            except Exception as err:
+                logger.warning("Failed to record ping to history: %s", err)
             try:
                 conn.disconnect()
             except Exception:

--- a/neteye/troubleshoot/routes.py
+++ b/neteye/troubleshoot/routes.py
@@ -46,6 +46,15 @@ _SSE_DONE      = _sse_message("[DONE]")
 _SSE_SEPARATOR = _sse_message("")   # blank line between header info and streaming output
 
 
+def _sse_partial(text: str) -> str:
+    """Partial SSE event — hop line in progress (e.g. * * * probes accumulating).
+
+    The client replaces the previous partial content with this text rather than
+    appending, so consecutive partials never cascade into a single garbled line.
+    """
+    return f"event: partial\ndata: {text}\n\n"
+
+
 # ── Annotation helpers ────────────────────────────────────────────────
 
 def _annotate_ip(ip_address: str) -> str | None:
@@ -246,7 +255,9 @@ def ping_stream():
                     chunk = conn.read_channel()
                     if chunk:
                         buffer += chunk
-                        for line in chunk.splitlines():
+                        # Normalize line endings: \r\n → \n, then strip bare \r
+                        # (Cisco uses \r to reprint the "!!!!!" progress line in-place).
+                        for line in chunk.replace("\r\n", "\n").replace("\r", "").split("\n"):
                             if line.strip():
                                 output_lines.append(line)
                                 yield _sse_message(line)
@@ -378,18 +389,51 @@ def traceroute_stream():
                 time.sleep(0.2)
 
                 buffer = ""
+                line_buffer = ""
+                line_buffer_ts = time.time()
                 while time.time() < deadline:
                     chunk = conn.read_channel()
                     if chunk:
                         buffer += chunk
-                        for line in chunk.splitlines():
+                        # Normalize \r\n → \n, then split on \n to get complete lines.
+                        # Bare \r (no \n) means Cisco overwrote the terminal cursor back
+                        # to line start (probe-by-probe update for * * * hops);
+                        # split("\r")[-1] keeps only the final overwrite state.
+                        data = line_buffer + chunk.replace("\r\n", "\n")
+                        parts = data.split("\n")
+                        line_buffer = parts.pop()   # last (incomplete) segment
+                        line_buffer_ts = time.time()
+                        for raw_line in parts:
+                            line = raw_line.split("\r")[-1]
                             if line.strip():
                                 output_lines.append(line)
                                 yield _sse_message(_annotate_traceroute_line(line))
                         if prompt in buffer:
                             break
                     else:
+                        # No new data — emit a partial event showing the current state
+                        # of the in-progress hop line (e.g. "  5  * *" while still waiting
+                        # for the third probe to time out). Client replaces the previous
+                        # partial rather than appending, so no cascade occurs.
+                        if line_buffer.strip() and time.time() - line_buffer_ts > 1.0:
+                            partial = next(
+                                (s for s in reversed(line_buffer.split("\r")) if s.strip()),
+                                "",
+                            )
+                            if partial:
+                                yield _sse_partial(_annotate_traceroute_line(partial))
+                            line_buffer_ts = time.time()  # reset to avoid re-sending same partial
                         time.sleep(0.3)
+
+                # Flush any remaining partial line (e.g. the device prompt).
+                if line_buffer.strip():
+                    line = next(
+                        (s for s in reversed(line_buffer.split("\r")) if s.strip()),
+                        "",
+                    )
+                    if line:
+                        output_lines.append(line)
+                        yield _sse_message(_annotate_traceroute_line(line))
 
             history_result = "\n".join(output_lines)
 

--- a/neteye/troubleshoot/templates/troubleshoot/ping.html
+++ b/neteye/troubleshoot/templates/troubleshoot/ping.html
@@ -93,6 +93,8 @@
                  es.close(); es = null;
                  $cancel.hide();
                  $submit.prop('disabled', false).val('Submit');
+                 $output.text($output.text() + '\n[Done]');
+                 $output[0].scrollTop = $output[0].scrollHeight;
                  return;
              }
              $output.text($output.text() + evt.data + '\n');

--- a/neteye/troubleshoot/templates/troubleshoot/traceroute.html
+++ b/neteye/troubleshoot/templates/troubleshoot/traceroute.html
@@ -42,6 +42,18 @@
      // ── SSE-based real-time traceroute execution ──────────────────────
      var es = null;
 
+     // completedText holds finalized lines; partialText holds the current
+     // in-progress hop line (e.g. "  5  * *" while the third probe is pending).
+     // Keeping them separate lets partial events REPLACE rather than APPEND,
+     // which prevents consecutive partials from cascading into one garbled line.
+     var completedText = '';
+     var partialText   = '';
+
+     function updateOutput($output) {
+         $output.text(completedText + partialText);
+         $output[0].scrollTop = $output[0].scrollHeight;
+     }
+
      var $cancel = $('#cancel');
 
      $cancel.on('click', function() {
@@ -49,8 +61,9 @@
          $cancel.hide();
          $('#submit').prop('disabled', false).val('Submit');
          var $output = $('#result-output');
-         $output.text($output.text() + '\n[Cancelled]');
-         $output[0].scrollTop = $output[0].scrollHeight;
+         if (partialText) { completedText += partialText + '\n'; partialText = ''; }
+         completedText += '\n[Cancelled]';
+         updateOutput($output);
      });
 
      $('#traceroute').on('submit', function(e) {
@@ -63,6 +76,8 @@
          var $output = $('#result-output');
          var $submit = $('#submit');
 
+         completedText = '';
+         partialText   = '';
          $output.text('');
          $card.show();
          $submit.prop('disabled', true).val('Running...');
@@ -88,22 +103,36 @@
 
          es = new EventSource('{{ url_for("troubleshoot.traceroute_stream") }}?' + params.toString());
 
+         // "partial" events: REPLACE partialText with the current hop-line state.
+         // Because we replace (not append), consecutive partials never cascade.
+         es.addEventListener('partial', function(evt) {
+             partialText = evt.data;
+             updateOutput($output);
+         });
+
+         // Default "message" events: complete lines.
+         // If a partial was in progress, discard it (the complete line supersedes it).
          es.onmessage = function(evt) {
+             partialText = '';
              if (evt.data === '[DONE]') {
                  es.close(); es = null;
                  $cancel.hide();
                  $submit.prop('disabled', false).val('Submit');
+                 completedText += '\n[Done]';
+                 updateOutput($output);
                  return;
              }
-             $output.text($output.text() + evt.data + '\n');
-             $output[0].scrollTop = $output[0].scrollHeight;
+             completedText += evt.data + '\n';
+             updateOutput($output);
          };
 
          es.onerror = function() {
              if (es) { es.close(); es = null; }
              $cancel.hide();
              $submit.prop('disabled', false).val('Submit');
-             $output.text($output.text() + '\n[Connection closed]');
+             if (partialText) { completedText += partialText + '\n'; partialText = ''; }
+             completedText += '\n[Connection closed]';
+             updateOutput($output);
          };
      });
 

--- a/neteye/troubleshoot/templates/troubleshoot/traceroute.html
+++ b/neteye/troubleshoot/templates/troubleshoot/traceroute.html
@@ -1,0 +1,214 @@
+{% extends "base_template.html" %}
+
+{% block javascript %}
+{{ super() }}
+
+<script>
+ $(document).ready(function(){
+     var ipOpts = {
+         valueKey: 'ip_address',
+         textFn:   function(intf) { return intf.ip_address + ' (' + intf.name + ')'; },
+         filter:   function(intf) { return intf.ip_address && intf.ip_address !== 'unassigned'; }
+     };
+
+     // ── localStorage: restore last used values ────────────────────────
+     var STORAGE_PREFIX = 'neteye_traceroute_';  // key prefix — avoids collision with DataTables keys
+     var savedNodeId = localStorage.getItem(STORAGE_PREFIX + 'node_id');
+     var savedSrcIp  = localStorage.getItem(STORAGE_PREFIX + 'src_ip');
+
+     // Restore plain input fields
+     ['max_ttl', 'timeout', 'probe', 'vrf'].forEach(function(field) {
+         var v = localStorage.getItem(STORAGE_PREFIX + field);
+         if (v !== null) { $('#' + field).val(v); }
+     });
+
+     // Apply Select2 to node selector for search-as-you-type
+     $('#src_node').select2({ theme: 'bootstrap4', width: '100%' });
+
+     // Apply Select2 to IP selector; mark it for auto-reinit after loadInterfaces
+     $('#src_ip_address').data('select2-init', true).select2({ theme: 'bootstrap4', width: '100%' });
+
+     // Restore node selection, then load its interfaces (pre-selecting saved src_ip)
+     if (savedNodeId) {
+         $('#src_node').val(savedNodeId).trigger('change');
+     }
+     loadInterfaces($('#src_node').val(), 'src_ip_address',
+                    $.extend({}, ipOpts, { selectedValue: savedSrcIp }));
+
+     $('#src_node').on('select2:select', function(){
+         loadInterfaces($(this).val(), 'src_ip_address', ipOpts);
+     });
+
+     // ── SSE-based real-time traceroute execution ──────────────────────
+     var es = null;
+
+     var $cancel = $('#cancel');
+
+     $cancel.on('click', function() {
+         if (es) { es.close(); es = null; }
+         $cancel.hide();
+         $('#submit').prop('disabled', false).val('Submit');
+         var $output = $('#result-output');
+         $output.text($output.text() + '\n[Cancelled]');
+         $output[0].scrollTop = $output[0].scrollHeight;
+     });
+
+     $('#traceroute').on('submit', function(e) {
+         e.preventDefault();
+
+         // Close any in-progress stream
+         if (es) { es.close(); es = null; }
+
+         var $card   = $('#result-card');
+         var $output = $('#result-output');
+         var $submit = $('#submit');
+
+         $output.text('');
+         $card.show();
+         $submit.prop('disabled', true).val('Running...');
+         $cancel.show();
+
+         // Save current values to localStorage before execution
+         localStorage.setItem(STORAGE_PREFIX + 'node_id', $('#src_node').val());
+         localStorage.setItem(STORAGE_PREFIX + 'src_ip',  $('#src_ip_address').val() || '');
+         localStorage.setItem(STORAGE_PREFIX + 'vrf',     $('#vrf').val() || '');
+         localStorage.setItem(STORAGE_PREFIX + 'max_ttl', $('#max_ttl').val());
+         localStorage.setItem(STORAGE_PREFIX + 'timeout', $('#timeout').val());
+         localStorage.setItem(STORAGE_PREFIX + 'probe',   $('#probe').val());
+
+         var params = new URLSearchParams({
+             node_id: $('#src_node').val(),
+             dst_ip:  $('#dst_ip_address').val(),
+             src_ip:  $('#src_ip_address').val() || '',
+             vrf:     $('#vrf').val() || '',
+             max_ttl: $('#max_ttl').val(),
+             timeout: $('#timeout').val(),
+             probe:   $('#probe').val()
+         });
+
+         es = new EventSource('{{ url_for("troubleshoot.traceroute_stream") }}?' + params.toString());
+
+         es.onmessage = function(evt) {
+             if (evt.data === '[DONE]') {
+                 es.close(); es = null;
+                 $cancel.hide();
+                 $submit.prop('disabled', false).val('Submit');
+                 return;
+             }
+             $output.text($output.text() + evt.data + '\n');
+             $output[0].scrollTop = $output[0].scrollHeight;
+         };
+
+         es.onerror = function() {
+             if (es) { es.close(); es = null; }
+             $cancel.hide();
+             $submit.prop('disabled', false).val('Submit');
+             $output.text($output.text() + '\n[Connection closed]');
+         };
+     });
+
+     // Reset handler
+     $('#traceroute').on('reset', function() {
+         setTimeout(function() {
+             $('#src_node').trigger('change');
+             loadInterfaces($('#src_node').val(), 'src_ip_address', ipOpts);
+         }, 0);
+     });
+ });
+</script>
+{% endblock javascript %}
+
+
+{% block main %}
+{% with messages = get_flashed_messages(with_categories=true) %}
+  {% if messages %}
+    {% for category, message in messages %}
+      <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
+        {{ message }}
+        <button type="button" class="close" data-dismiss="alert">&times;</button>
+      </div>
+    {% endfor %}
+  {% endif %}
+{% endwith %}
+
+<div class="card">
+    <div class="card-header">
+        Traceroute
+    </div>
+    <div class="card-body">
+        <form action="#" method="post" class="form-horizontal" id="traceroute">
+            {{ form.csrf_token }}
+            <div class="form-group row">
+                {{ form.src_node.label(class_="col-md-3 col-form-label") }}
+                <div class="col-md-6">
+                    {{ form.src_node(class_="form-control") }}
+                </div>
+            </div>
+            <div class="form-group row">
+                {{ form.src_ip_address.label(class_="col-md-3 col-form-label") }}
+                <div class="col-md-6">
+                    {{ form.src_ip_address(class_="form-control") }}
+                </div>
+            </div>
+            <div class="form-group row">
+                {{ form.vrf.label(class_="col-md-3 col-form-label") }}
+                <div class="col-md-6">
+                    {{ form.vrf(class_="form-control", placeholder="(optional)") }}
+                </div>
+            </div>
+            <div class="form-group row">
+                {{ form.dst_ip_address.label(class_="col-md-3 col-form-label") }}
+                <div class="col-md-6">
+                    {{ form.dst_ip_address(class_="form-control") }}
+                    {% if form.dst_ip_address.errors %}
+                      <div class="alert-danger">{{ form.dst_ip_address.errors[0] }}</div>
+                    {% endif %}
+                </div>
+            </div>
+            <div class="form-group row">
+                {{ form.max_ttl.label(class_="col-md-3 col-form-label") }}
+                <div class="col-md-6">
+                    {{ form.max_ttl(class_="form-control") }}
+                    {% if form.max_ttl.errors %}
+                      <div class="alert-danger">{{ form.max_ttl.errors[0] }}</div>
+                    {% endif %}
+                </div>
+            </div>
+            <div class="form-group row">
+                {{ form.probe.label(class_="col-md-3 col-form-label") }}
+                <div class="col-md-6">
+                    {{ form.probe(class_="form-control") }}
+                    {% if form.probe.errors %}
+                      <div class="alert-danger">{{ form.probe.errors[0] }}</div>
+                    {% endif %}
+                </div>
+            </div>
+            <div class="form-group row">
+                {{ form.timeout.label(class_="col-md-3 col-form-label") }}
+                <div class="col-md-6">
+                    {{ form.timeout(class_="form-control") }}
+                    {% if form.timeout.errors %}
+                      <div class="alert-danger">{{ form.timeout.errors[0] }}</div>
+                    {% endif %}
+                </div>
+            </div>
+        </form>
+    </div>
+    <div class="card-footer">
+        {{ form.submit(class_="btn btn-sm btn-primary", form="traceroute") }}
+        {{ form.reset(type="reset", class_="btn btn-sm btn-danger", form="traceroute") }}
+    </div>
+</div>
+
+{# SSE real-time result card (shown by JavaScript when streaming starts) #}
+<div id="result-card" class="card mt-3" style="display:none;">
+    <div class="card-header d-flex justify-content-between align-items-center">
+        <span>Result</span>
+        <button type="button" class="btn btn-warning" id="cancel">Cancel</button>
+    </div>
+    <div class="card-body p-0">
+        <pre id="result-output" class="bg-dark text-white p-3 rounded mb-0"
+             style="max-height:500px; overflow-y:auto; white-space:pre-wrap;"></pre>
+    </div>
+</div>
+{% endblock main %}

--- a/settings.toml
+++ b/settings.toml
@@ -60,6 +60,11 @@ PING_MAX_COUNT     = 10000
 PING_MAX_TIMEOUT   = 100
 PING_MAX_DATA_SIZE = 1500
 
+# Traceroute Settings
+# Upper limits for traceroute form fields. Override in settings.local.toml if needed.
+TRACEROUTE_MAX_TTL     = 255
+TRACEROUTE_MAX_TIMEOUT = 100
+
 # History Settings
 # Maximum number of history records to keep in database for each type
 # NOTE: Set to 0 for unlimited records

--- a/tests/test_troubleshoot_command_builder.py
+++ b/tests/test_troubleshoot_command_builder.py
@@ -22,12 +22,14 @@ from neteye.lib.troubleshoot_command_builder import (
 
 # ── 共通フィクスチャ ─────────────────────────────────────────────────
 
-DST = "10.0.0.1"
-SRC = "192.168.1.1"
-VRF = "MGMT"
-COUNT = 5
+DST     = "10.0.0.1"
+SRC     = "192.168.1.1"
+VRF     = "MGMT"
+COUNT   = 5
 TIMEOUT = 2
-SIZE = 100
+SIZE    = 100
+MAX_TTL = 30
+PROBE   = 3
 
 
 # ── get_troubleshoot_builder ─────────────────────────────────────────
@@ -207,14 +209,172 @@ class TestFortinetTroubleshootBuilder:
         assert commands[-1] == f"execute ping {DST}"
 
 
-# ── build_traceroute / build_telnet は NotImplementedError ──────────
+# ── Cisco IOS / IOS-XE traceroute ────────────────────────────────────
+
+class TestCiscoIOSTroubleshootBuilderTraceroute:
+    builder = CiscoIOSTroubleshootBuilder()
+
+    def test_full_options(self):
+        cmd = self.builder.build_traceroute(DST, SRC, VRF, PROBE, TIMEOUT, MAX_TTL)
+        assert cmd == "traceroute vrf MGMT 10.0.0.1 source 192.168.1.1 probe 3 timeout 2 ttl 1 30"
+
+    def test_no_vrf(self):
+        cmd = self.builder.build_traceroute(DST, SRC, None, PROBE, TIMEOUT, MAX_TTL)
+        assert cmd.startswith("traceroute 10.0.0.1")
+        assert "vrf" not in cmd
+
+    def test_no_src_ip(self):
+        cmd = self.builder.build_traceroute(DST, None, VRF, PROBE, TIMEOUT, MAX_TTL)
+        assert "source" not in cmd
+
+    def test_minimal(self):
+        cmd = self.builder.build_traceroute(DST, None, None, PROBE, TIMEOUT, MAX_TTL)
+        assert cmd == "traceroute 10.0.0.1 probe 3 timeout 2 ttl 1 30"
+
+
+# ── Cisco NX-OS traceroute ────────────────────────────────────────────
+
+class TestCiscoNXOSTroubleshootBuilderTraceroute:
+    builder = CiscoNXOSTroubleshootBuilder()
+
+    def test_full_options(self):
+        cmd = self.builder.build_traceroute(DST, SRC, VRF, PROBE, TIMEOUT, MAX_TTL)
+        assert "traceroute 10.0.0.1" in cmd
+        assert "source 192.168.1.1" in cmd
+        assert "vrf MGMT" in cmd
+        assert f"probe {PROBE}" in cmd
+        assert f"timeout {TIMEOUT}" in cmd
+
+    def test_max_ttl_ignored(self):
+        # NX-OS does not support max-ttl
+        cmd = self.builder.build_traceroute(DST, None, None, PROBE, TIMEOUT, MAX_TTL)
+        assert str(MAX_TTL) not in cmd
+
+    def test_no_vrf(self):
+        cmd = self.builder.build_traceroute(DST, SRC, None, PROBE, TIMEOUT, MAX_TTL)
+        assert "vrf" not in cmd
+
+    def test_no_src_ip(self):
+        cmd = self.builder.build_traceroute(DST, None, VRF, PROBE, TIMEOUT, MAX_TTL)
+        assert "source" not in cmd
+
+
+# ── Cisco IOS-XR traceroute ───────────────────────────────────────────
+
+class TestCiscoXRTroubleshootBuilderTraceroute:
+    builder = CiscoXRTroubleshootBuilder()
+
+    def test_full_options(self):
+        cmd = self.builder.build_traceroute(DST, SRC, VRF, PROBE, TIMEOUT, MAX_TTL)
+        assert cmd == "traceroute vrf MGMT 10.0.0.1 source 192.168.1.1 probe 3 timeout 2 max-ttl 30"
+
+    def test_no_vrf(self):
+        cmd = self.builder.build_traceroute(DST, SRC, None, PROBE, TIMEOUT, MAX_TTL)
+        assert cmd.startswith("traceroute 10.0.0.1")
+        assert "vrf" not in cmd
+
+    def test_max_ttl_present(self):
+        cmd = self.builder.build_traceroute(DST, None, None, PROBE, TIMEOUT, MAX_TTL)
+        assert f"max-ttl {MAX_TTL}" in cmd
+
+
+# ── Arista EOS traceroute ─────────────────────────────────────────────
+
+class TestAristaEOSTroubleshootBuilderTraceroute:
+    builder = AristaEOSTroubleshootBuilder()
+
+    def test_full_options(self):
+        cmd = self.builder.build_traceroute(DST, SRC, VRF, PROBE, TIMEOUT, MAX_TTL)
+        assert "traceroute 10.0.0.1" in cmd
+        assert "source 192.168.1.1" in cmd
+        assert f"probe {PROBE}" in cmd
+        assert f"maxttl {MAX_TTL}" in cmd
+
+    def test_timeout_ignored(self):
+        # Arista does not support a timeout option
+        cmd = self.builder.build_traceroute(DST, None, None, PROBE, TIMEOUT, MAX_TTL)
+        assert "timeout" not in cmd
+
+    def test_no_src_ip(self):
+        cmd = self.builder.build_traceroute(DST, None, VRF, PROBE, TIMEOUT, MAX_TTL)
+        assert "source" not in cmd
+
+
+# ── Juniper JunOS traceroute ──────────────────────────────────────────
+
+class TestJuniperJunOSTroubleshootBuilderTraceroute:
+    builder = JuniperJunOSTroubleshootBuilder()
+
+    def test_full_options(self):
+        cmd = self.builder.build_traceroute(DST, SRC, VRF, PROBE, TIMEOUT, MAX_TTL)
+        assert "traceroute 10.0.0.1" in cmd
+        assert "source 192.168.1.1" in cmd
+        assert "routing-instance MGMT" in cmd
+        assert f"probe-count {PROBE}" in cmd
+        assert f"wait {TIMEOUT}" in cmd
+        assert f"ttl {MAX_TTL}" in cmd
+
+    def test_vrf_keyword_is_routing_instance(self):
+        cmd = self.builder.build_traceroute(DST, None, VRF, PROBE, TIMEOUT, MAX_TTL)
+        assert "routing-instance MGMT" in cmd
+        assert "vrf" not in cmd
+
+    def test_no_vrf(self):
+        cmd = self.builder.build_traceroute(DST, SRC, None, PROBE, TIMEOUT, MAX_TTL)
+        assert "routing-instance" not in cmd
+
+
+# ── Palo Alto PAN-OS traceroute ───────────────────────────────────────
+
+class TestPaloAltoTroubleshootBuilderTraceroute:
+    builder = PaloAltoTroubleshootBuilder()
+
+    def test_basic(self):
+        cmd = self.builder.build_traceroute(DST, None, None, PROBE, TIMEOUT, MAX_TTL)
+        assert cmd == "traceroute host 10.0.0.1"
+
+    def test_with_src_ip(self):
+        cmd = self.builder.build_traceroute(DST, SRC, None, PROBE, TIMEOUT, MAX_TTL)
+        assert cmd == "traceroute host 10.0.0.1 source 192.168.1.1"
+
+    def test_vrf_ignored(self):
+        # PAN-OS traceroute does not support vrouter
+        cmd = self.builder.build_traceroute(DST, None, VRF, PROBE, TIMEOUT, MAX_TTL)
+        assert "vrouter" not in cmd
+
+
+# ── Cisco ASA traceroute ──────────────────────────────────────────────
+
+class TestCiscoASATroubleshootBuilderTraceroute:
+    builder = CiscoASATroubleshootBuilder()
+
+    def test_basic(self):
+        cmd = self.builder.build_traceroute(DST, SRC, VRF, PROBE, TIMEOUT, MAX_TTL)
+        assert cmd == "traceroute 10.0.0.1"
+
+    def test_src_and_vrf_ignored(self):
+        cmd_with = self.builder.build_traceroute(DST, SRC, VRF, PROBE, TIMEOUT, MAX_TTL)
+        cmd_without = self.builder.build_traceroute(DST, None, None, PROBE, TIMEOUT, MAX_TTL)
+        assert cmd_with == cmd_without
+
+
+# ── Fortinet FortiOS traceroute ───────────────────────────────────────
+
+class TestFortinetTroubleshootBuilderTraceroute:
+    builder = FortinetTroubleshootBuilder()
+
+    def test_returns_str(self):
+        result = self.builder.build_traceroute(DST, SRC, VRF, PROBE, TIMEOUT, MAX_TTL)
+        assert isinstance(result, str)
+
+    def test_command(self):
+        cmd = self.builder.build_traceroute(DST, SRC, VRF, PROBE, TIMEOUT, MAX_TTL)
+        assert cmd == "execute traceroute 10.0.0.1"
+
+
+# ── build_telnet は NotImplementedError ──────────────────────────────
 
 class TestNotImplementedMethods:
-    def test_traceroute_raises(self):
-        builder = CiscoIOSTroubleshootBuilder()
-        with pytest.raises(NotImplementedError):
-            builder.build_traceroute(DST, SRC, VRF, COUNT, TIMEOUT, SIZE)
-
     def test_telnet_raises(self):
         builder = CiscoIOSTroubleshootBuilder()
         with pytest.raises(NotImplementedError):


### PR DESCRIPTION
## Summary

- Add `traceroute` / `traceroute_stream` SSE routes with per-device command builder (`build_traceroute()`) for Cisco IOS/XE/NX-OS/XR, Arista EOS, Juniper JunOS, Palo Alto, ASA, Fortinet
- Add `TracerouteForm` with `dst_ip`, `src_node`, `src_ip`, `vrf`, `max_ttl`, `probe`, `timeout` fields
- Add `traceroute.html` template with real-time SSE output, localStorage persistence, and Select2 node/IP selectors
- Annotate hop IP addresses with Node/Interface DB lookups (same as ping)
- Fix `\r` overwrite handling in streaming: `\n`-split + `split("\r")[-1]` so Cisco's probe-by-probe cursor overwrites produce clean final-state lines instead of cascaded garbled output
- Add `completedText`/`partialText` client-side split for race-free partial hop display (1 s interval SSE partial events replace in-place rather than append)
- Add `[Done]` marker on completion for both traceroute and ping

## Test plan

- [ ] `ENV_FOR_DYNACONF=testing python -m pytest` — 89 passed
- [ ] Traceroute to reachable destination: all hops display on separate lines with RTT
- [ ] Traceroute with `* * *` hops: partial updates appear ~1 s apart on same line, then finalize cleanly
- [ ] Cancel during execution: `[Cancelled]` displayed, SSH interrupt sent
- [ ] CommandHistory record created after completion
- [ ] Ping `[Done]` marker displayed on completion