### PR TITLE
fix: increase default connection timeouts from 1s to 5s

### DIFF
--- a/settings.toml
+++ b/settings.toml
@@ -4,7 +4,7 @@
 #
 #   [default]
 #   SQLALCHEMY_DATABASE_URI = "sqlite:////home/user/neteye.db"
-#   NETMIKO_CONN_TIMEOUT = 5
+#   NETMIKO_CONN_TIMEOUT = 10
 #
 # settings.local.toml is gitignored and will never be overwritten by git pull.
 
@@ -45,14 +45,14 @@ CUSTOM_TEMPLATES_DIR = ''
 
 # Device Connection Setting
 NETMIKO_READ_TIMEOUT = 10
-NETMIKO_CONN_TIMEOUT = 1
-NETMIKO_AUTH_TIMEOUT = 1
-NETMIKO_BANNER_TIMEOUT = 1
+NETMIKO_CONN_TIMEOUT = 5
+NETMIKO_AUTH_TIMEOUT = 5
+NETMIKO_BANNER_TIMEOUT = 5
 NETMIKO_KEEPALIVE = 5
-SCRAPLI_TIMEOUT_SOCKET = 1
-SCRAPLI_TIMEOUT_TRANSPORT = 1
-SCRAPLI_TIMEOUT_OPS = 1
-NAPALM_TIMEOUT = 1
+SCRAPLI_TIMEOUT_SOCKET = 5
+SCRAPLI_TIMEOUT_TRANSPORT = 5
+SCRAPLI_TIMEOUT_OPS = 5
+NAPALM_TIMEOUT = 5
 
 # Ping Settings
 # Upper limits for ping form fields. Override in settings.local.toml if needed.


### PR DESCRIPTION
## Summary
- `NETMIKO_CONN_TIMEOUT`, `NETMIKO_AUTH_TIMEOUT`, `NETMIKO_BANNER_TIMEOUT` を 1s → 5s に変更
- `SCRAPLI_TIMEOUT_SOCKET`, `SCRAPLI_TIMEOUT_TRANSPORT`, `SCRAPLI_TIMEOUT_OPS` を 1s → 5s に変更
- `NAPALM_TIMEOUT` を 1s → 5s に変更

## Background
デフォルト値 1秒は、IOL等の仮想デバイスや古い SSH アルゴリズム (`diffie-hellman-group14-sha1`) を使うデバイスで認証タイムアウトを引き起こしていた。`settings.toml` コメント例とも整合する変更。

## Test plan
- [ ] `ENV_FOR_DYNACONF=testing python -m pytest` がグリーンであること
- [ ] Cisco IOL デバイスへの SSH 接続が成功すること