### PR TITLE
fix(troubleshoot): remove unsupported probe/timeout from NX-OS traceroute

### DIFF
--- a/neteye/lib/troubleshoot_command_builder.py
+++ b/neteye/lib/troubleshoot_command_builder.py
@@ -127,14 +127,12 @@ class CiscoNXOSTroubleshootBuilder(TroubleshootBuilder):
         return " ".join(command)
 
     def build_traceroute(self, dst_ip, src_ip, vrf, probe, timeout, max_ttl) -> str:
-        # traceroute DST [source SRC] [vrf VRF] probe N timeout N
-        # NX-OS does not support a max-ttl option (max_ttl is ignored)
+        # traceroute DST [vrf VRF] [source SRC]
+        # NX-OS does not support probe, timeout, or max-ttl options (all ignored).
         command  = ["traceroute"]
         command += [dst_ip]
-        command += self._optional("source", src_ip)
         command += self._optional("vrf", vrf)
-        command += [f"probe {probe}"]
-        command += [f"timeout {timeout}"]
+        command += self._optional("source", src_ip)
         return " ".join(command)
 
 

--- a/tests/test_troubleshoot_command_builder.py
+++ b/tests/test_troubleshoot_command_builder.py
@@ -215,21 +215,21 @@ class TestCiscoIOSTroubleshootBuilderTraceroute:
     builder = CiscoIOSTroubleshootBuilder()
 
     def test_full_options(self):
-        cmd = self.builder.build_traceroute(DST, SRC, VRF, PROBE, TIMEOUT, MAX_TTL)
-        assert cmd == "traceroute vrf MGMT 10.0.0.1 source 192.168.1.1 probe 3 timeout 2 ttl 1 30"
+        command = self.builder.build_traceroute(DST, SRC, VRF, PROBE, TIMEOUT, MAX_TTL)
+        assert command == "traceroute vrf MGMT 10.0.0.1 source 192.168.1.1 probe 3 timeout 2 ttl 1 30"
 
     def test_no_vrf(self):
-        cmd = self.builder.build_traceroute(DST, SRC, None, PROBE, TIMEOUT, MAX_TTL)
-        assert cmd.startswith("traceroute 10.0.0.1")
-        assert "vrf" not in cmd
+        command = self.builder.build_traceroute(DST, SRC, None, PROBE, TIMEOUT, MAX_TTL)
+        assert command.startswith("traceroute 10.0.0.1")
+        assert "vrf" not in command
 
     def test_no_src_ip(self):
-        cmd = self.builder.build_traceroute(DST, None, VRF, PROBE, TIMEOUT, MAX_TTL)
-        assert "source" not in cmd
+        command = self.builder.build_traceroute(DST, None, VRF, PROBE, TIMEOUT, MAX_TTL)
+        assert "source" not in command
 
     def test_minimal(self):
-        cmd = self.builder.build_traceroute(DST, None, None, PROBE, TIMEOUT, MAX_TTL)
-        assert cmd == "traceroute 10.0.0.1 probe 3 timeout 2 ttl 1 30"
+        command = self.builder.build_traceroute(DST, None, None, PROBE, TIMEOUT, MAX_TTL)
+        assert command == "traceroute 10.0.0.1 probe 3 timeout 2 ttl 1 30"
 
 
 # ── Cisco NX-OS traceroute ────────────────────────────────────────────
@@ -238,25 +238,28 @@ class TestCiscoNXOSTroubleshootBuilderTraceroute:
     builder = CiscoNXOSTroubleshootBuilder()
 
     def test_full_options(self):
-        cmd = self.builder.build_traceroute(DST, SRC, VRF, PROBE, TIMEOUT, MAX_TTL)
-        assert "traceroute 10.0.0.1" in cmd
-        assert "source 192.168.1.1" in cmd
-        assert "vrf MGMT" in cmd
-        assert f"probe {PROBE}" in cmd
-        assert f"timeout {TIMEOUT}" in cmd
+        command = self.builder.build_traceroute(DST, SRC, VRF, PROBE, TIMEOUT, MAX_TTL)
+        assert "traceroute 10.0.0.1" in command
+        assert "source 192.168.1.1" in command
+        assert "vrf MGMT" in command
+        # NX-OS does not support probe or timeout options
+        assert "probe" not in command
+        assert "timeout" not in command
 
     def test_max_ttl_ignored(self):
-        # NX-OS does not support max-ttl
-        cmd = self.builder.build_traceroute(DST, None, None, PROBE, TIMEOUT, MAX_TTL)
-        assert str(MAX_TTL) not in cmd
+        # NX-OS does not support max-ttl, probe, or timeout
+        command = self.builder.build_traceroute(DST, None, None, PROBE, TIMEOUT, MAX_TTL)
+        assert str(MAX_TTL) not in command
+        assert "probe" not in command
+        assert "timeout" not in command
 
     def test_no_vrf(self):
-        cmd = self.builder.build_traceroute(DST, SRC, None, PROBE, TIMEOUT, MAX_TTL)
-        assert "vrf" not in cmd
+        command = self.builder.build_traceroute(DST, SRC, None, PROBE, TIMEOUT, MAX_TTL)
+        assert "vrf" not in command
 
     def test_no_src_ip(self):
-        cmd = self.builder.build_traceroute(DST, None, VRF, PROBE, TIMEOUT, MAX_TTL)
-        assert "source" not in cmd
+        command = self.builder.build_traceroute(DST, None, VRF, PROBE, TIMEOUT, MAX_TTL)
+        assert "source" not in command
 
 
 # ── Cisco IOS-XR traceroute ───────────────────────────────────────────
@@ -265,17 +268,17 @@ class TestCiscoXRTroubleshootBuilderTraceroute:
     builder = CiscoXRTroubleshootBuilder()
 
     def test_full_options(self):
-        cmd = self.builder.build_traceroute(DST, SRC, VRF, PROBE, TIMEOUT, MAX_TTL)
-        assert cmd == "traceroute vrf MGMT 10.0.0.1 source 192.168.1.1 probe 3 timeout 2 max-ttl 30"
+        command = self.builder.build_traceroute(DST, SRC, VRF, PROBE, TIMEOUT, MAX_TTL)
+        assert command == "traceroute vrf MGMT 10.0.0.1 source 192.168.1.1 probe 3 timeout 2 max-ttl 30"
 
     def test_no_vrf(self):
-        cmd = self.builder.build_traceroute(DST, SRC, None, PROBE, TIMEOUT, MAX_TTL)
-        assert cmd.startswith("traceroute 10.0.0.1")
-        assert "vrf" not in cmd
+        command = self.builder.build_traceroute(DST, SRC, None, PROBE, TIMEOUT, MAX_TTL)
+        assert command.startswith("traceroute 10.0.0.1")
+        assert "vrf" not in command
 
     def test_max_ttl_present(self):
-        cmd = self.builder.build_traceroute(DST, None, None, PROBE, TIMEOUT, MAX_TTL)
-        assert f"max-ttl {MAX_TTL}" in cmd
+        command = self.builder.build_traceroute(DST, None, None, PROBE, TIMEOUT, MAX_TTL)
+        assert f"max-ttl {MAX_TTL}" in command
 
 
 # ── Arista EOS traceroute ─────────────────────────────────────────────
@@ -284,20 +287,20 @@ class TestAristaEOSTroubleshootBuilderTraceroute:
     builder = AristaEOSTroubleshootBuilder()
 
     def test_full_options(self):
-        cmd = self.builder.build_traceroute(DST, SRC, VRF, PROBE, TIMEOUT, MAX_TTL)
-        assert "traceroute 10.0.0.1" in cmd
-        assert "source 192.168.1.1" in cmd
-        assert f"probe {PROBE}" in cmd
-        assert f"maxttl {MAX_TTL}" in cmd
+        command = self.builder.build_traceroute(DST, SRC, VRF, PROBE, TIMEOUT, MAX_TTL)
+        assert "traceroute 10.0.0.1" in command
+        assert "source 192.168.1.1" in command
+        assert f"probe {PROBE}" in command
+        assert f"maxttl {MAX_TTL}" in command
 
     def test_timeout_ignored(self):
         # Arista does not support a timeout option
-        cmd = self.builder.build_traceroute(DST, None, None, PROBE, TIMEOUT, MAX_TTL)
-        assert "timeout" not in cmd
+        command = self.builder.build_traceroute(DST, None, None, PROBE, TIMEOUT, MAX_TTL)
+        assert "timeout" not in command
 
     def test_no_src_ip(self):
-        cmd = self.builder.build_traceroute(DST, None, VRF, PROBE, TIMEOUT, MAX_TTL)
-        assert "source" not in cmd
+        command = self.builder.build_traceroute(DST, None, VRF, PROBE, TIMEOUT, MAX_TTL)
+        assert "source" not in command
 
 
 # ── Juniper JunOS traceroute ──────────────────────────────────────────
@@ -306,22 +309,22 @@ class TestJuniperJunOSTroubleshootBuilderTraceroute:
     builder = JuniperJunOSTroubleshootBuilder()
 
     def test_full_options(self):
-        cmd = self.builder.build_traceroute(DST, SRC, VRF, PROBE, TIMEOUT, MAX_TTL)
-        assert "traceroute 10.0.0.1" in cmd
-        assert "source 192.168.1.1" in cmd
-        assert "routing-instance MGMT" in cmd
-        assert f"probe-count {PROBE}" in cmd
-        assert f"wait {TIMEOUT}" in cmd
-        assert f"ttl {MAX_TTL}" in cmd
+        command = self.builder.build_traceroute(DST, SRC, VRF, PROBE, TIMEOUT, MAX_TTL)
+        assert "traceroute 10.0.0.1" in command
+        assert "source 192.168.1.1" in command
+        assert "routing-instance MGMT" in command
+        assert f"probe-count {PROBE}" in command
+        assert f"wait {TIMEOUT}" in command
+        assert f"ttl {MAX_TTL}" in command
 
     def test_vrf_keyword_is_routing_instance(self):
-        cmd = self.builder.build_traceroute(DST, None, VRF, PROBE, TIMEOUT, MAX_TTL)
-        assert "routing-instance MGMT" in cmd
-        assert "vrf" not in cmd
+        command = self.builder.build_traceroute(DST, None, VRF, PROBE, TIMEOUT, MAX_TTL)
+        assert "routing-instance MGMT" in command
+        assert "vrf" not in command
 
     def test_no_vrf(self):
-        cmd = self.builder.build_traceroute(DST, SRC, None, PROBE, TIMEOUT, MAX_TTL)
-        assert "routing-instance" not in cmd
+        command = self.builder.build_traceroute(DST, SRC, None, PROBE, TIMEOUT, MAX_TTL)
+        assert "routing-instance" not in command
 
 
 # ── Palo Alto PAN-OS traceroute ───────────────────────────────────────
@@ -330,17 +333,17 @@ class TestPaloAltoTroubleshootBuilderTraceroute:
     builder = PaloAltoTroubleshootBuilder()
 
     def test_basic(self):
-        cmd = self.builder.build_traceroute(DST, None, None, PROBE, TIMEOUT, MAX_TTL)
-        assert cmd == "traceroute host 10.0.0.1"
+        command = self.builder.build_traceroute(DST, None, None, PROBE, TIMEOUT, MAX_TTL)
+        assert command == "traceroute host 10.0.0.1"
 
     def test_with_src_ip(self):
-        cmd = self.builder.build_traceroute(DST, SRC, None, PROBE, TIMEOUT, MAX_TTL)
-        assert cmd == "traceroute host 10.0.0.1 source 192.168.1.1"
+        command = self.builder.build_traceroute(DST, SRC, None, PROBE, TIMEOUT, MAX_TTL)
+        assert command == "traceroute host 10.0.0.1 source 192.168.1.1"
 
     def test_vrf_ignored(self):
         # PAN-OS traceroute does not support vrouter
-        cmd = self.builder.build_traceroute(DST, None, VRF, PROBE, TIMEOUT, MAX_TTL)
-        assert "vrouter" not in cmd
+        command = self.builder.build_traceroute(DST, None, VRF, PROBE, TIMEOUT, MAX_TTL)
+        assert "vrouter" not in command
 
 
 # ── Cisco ASA traceroute ──────────────────────────────────────────────
@@ -349,13 +352,13 @@ class TestCiscoASATroubleshootBuilderTraceroute:
     builder = CiscoASATroubleshootBuilder()
 
     def test_basic(self):
-        cmd = self.builder.build_traceroute(DST, SRC, VRF, PROBE, TIMEOUT, MAX_TTL)
-        assert cmd == "traceroute 10.0.0.1"
+        command = self.builder.build_traceroute(DST, SRC, VRF, PROBE, TIMEOUT, MAX_TTL)
+        assert command == "traceroute 10.0.0.1"
 
     def test_src_and_vrf_ignored(self):
-        cmd_with = self.builder.build_traceroute(DST, SRC, VRF, PROBE, TIMEOUT, MAX_TTL)
-        cmd_without = self.builder.build_traceroute(DST, None, None, PROBE, TIMEOUT, MAX_TTL)
-        assert cmd_with == cmd_without
+        command_with = self.builder.build_traceroute(DST, SRC, VRF, PROBE, TIMEOUT, MAX_TTL)
+        command_without = self.builder.build_traceroute(DST, None, None, PROBE, TIMEOUT, MAX_TTL)
+        assert command_with == command_without
 
 
 # ── Fortinet FortiOS traceroute ───────────────────────────────────────
@@ -368,8 +371,8 @@ class TestFortinetTroubleshootBuilderTraceroute:
         assert isinstance(result, str)
 
     def test_command(self):
-        cmd = self.builder.build_traceroute(DST, SRC, VRF, PROBE, TIMEOUT, MAX_TTL)
-        assert cmd == "execute traceroute 10.0.0.1"
+        command = self.builder.build_traceroute(DST, SRC, VRF, PROBE, TIMEOUT, MAX_TTL)
+        assert command == "execute traceroute 10.0.0.1"
 
 
 # ── build_telnet は NotImplementedError ──────────────────────────────


### PR DESCRIPTION
## Summary

- NX-OS traceroute only supports `traceroute DST [vrf VRF] [source SRC]` — `probe`, `timeout`, and `max-ttl` options cause `% Invalid command` errors on real devices
- Removed unsupported params from `CiscoNXOSTroubleshootBuilder.build_traceroute` and reordered `vrf` before `source` to match device syntax
- Updated `TestCiscoNXOSTroubleshootBuilderTraceroute` assertions to verify these params are absent in the generated command
- Renamed `cmd` → `command` in traceroute test variables for consistency with the rest of the test file

## Test plan

- [ ] `ENV_FOR_DYNACONF=testing python -m pytest` — all 89 tests pass
- [ ] NX-OS traceroute from GUI no longer produces `% Invalid command` errors