### PR TITLE
fix(troubleshoot): fix NX-OS traceroute source/vrf argument order

### DIFF
--- a/neteye/lib/troubleshoot_command_builder.py
+++ b/neteye/lib/troubleshoot_command_builder.py
@@ -127,12 +127,12 @@ class CiscoNXOSTroubleshootBuilder(TroubleshootBuilder):
         return " ".join(command)
 
     def build_traceroute(self, dst_ip, src_ip, vrf, probe, timeout, max_ttl) -> str:
-        # traceroute DST [vrf VRF] [source SRC]
+        # traceroute DST [source SRC] [vrf VRF]
         # NX-OS does not support probe, timeout, or max-ttl options (all ignored).
         command  = ["traceroute"]
         command += [dst_ip]
-        command += self._optional("vrf", vrf)
         command += self._optional("source", src_ip)
+        command += self._optional("vrf", vrf)
         return " ".join(command)
 
 


### PR DESCRIPTION
## Summary

- NX-OS traceroute requires `traceroute DST source SRC vrf VRF` — `source` must precede `vrf`
- Previous order (`vrf` before `source`) caused `% Invalid command at '^' marker` errors on device

## Test plan

- [ ] `ENV_FOR_DYNACONF=testing python -m pytest` — all tests pass
- [ ] NX-OS traceroute with source IP and VRF executes without `% Invalid command` error