### PR TITLE
feat(traceroute): add per-hop table with node/interface links

### DIFF
--- a/neteye/troubleshoot/routes.py
+++ b/neteye/troubleshoot/routes.py
@@ -3,7 +3,7 @@ import logging
 import re
 import time
 
-from flask import Response, flash, render_template, request, stream_with_context
+from flask import Response, flash, render_template, request, stream_with_context, url_for
 from flask_security import auth_required, current_user
 
 from neteye.blueprints import bp_factory
@@ -74,21 +74,54 @@ def _annotate_ip(ip_address: str) -> str | None:
     return None
 
 
-_IP_RE = re.compile(r'\b(\d{1,3}(?:\.\d{1,3}){3})\b')
+def _sse_hop(data: dict) -> str:
+    """SSE hop event — structured hop data for table rendering."""
+    return f"event: hop\ndata: {json.dumps(data)}\n\n"
 
 
-def _annotate_traceroute_line(line: str) -> str:
-    """Annotate IPv4 addresses in a traceroute hop line with Node/Interface DB lookups.
+_HOP_LINE_RE = re.compile(
+    r'^\s*(\d+)\s+'                               # hop number
+    r'(?:\S+\s+\()?'                               # optional leading token + "(" — e.g. "192.168.0.1 (" or "dns.google ("
+    r'([\d.]+|\*)'                                 # IP or *
+    r'\)?'                                         # optional closing ")"
+    r'((?:\s+(?:[\d.]+\s*ms(?:ec)?|\*))+)'         # RTT values (ms or msec)
+)
 
-    Each IPv4 address found in the line is looked up via _annotate_ip().
-    If a match is found, the annotation is appended in brackets:
-      192.168.1.1  ->  192.168.1.1 [router1 (Gi0/0)]
+
+def _parse_traceroute_hop(line: str) -> dict | None:
+    """Parse a traceroute hop line into a structured dict for the hop table.
+
+    Returns None if the line does not match a hop pattern.
     """
-    def _replace(match: re.Match) -> str:
-        ip = match.group(1)
-        annotation = _annotate_ip(ip)
-        return f"{ip} [{annotation}]" if annotation else ip
-    return _IP_RE.sub(_replace, line)
+    m = _HOP_LINE_RE.match(line)
+    if not m:
+        return None
+    ip = m.group(2)
+    rtts = re.findall(r'[\d.]+\s*ms(?:ec)?|\*', m.group(3))
+
+    node_url = hostname = interface_name = interface_url = None
+    if ip != '*':
+        iface = Interface.query.filter_by(ip_address=ip).first()
+        if iface:
+            hostname = iface.node.hostname
+            interface_name = iface.name
+            node_url = url_for('node.show', id=iface.node_id)
+            interface_url = url_for('interface.show', id=iface.id)
+        else:
+            node = Node.query.filter_by(ip_address=ip).first()
+            if node:
+                hostname = node.hostname
+                node_url = url_for('node.show', id=node.id)
+
+    return {
+        "hop": int(m.group(1)),
+        "ip": ip,
+        "hostname": hostname,
+        "interface_name": interface_name,
+        "node_url": node_url,
+        "interface_url": interface_url,
+        "rtts": rtts,
+    }
 
 
 @troubleshoot_bp.route("/ping")
@@ -407,7 +440,10 @@ def traceroute_stream():
                             line = raw_line.split("\r")[-1]
                             if line.strip():
                                 output_lines.append(line)
-                                yield _sse_message(_annotate_traceroute_line(line))
+                                yield _sse_message(line)
+                                hop_data = _parse_traceroute_hop(line)
+                                if hop_data:
+                                    yield _sse_hop(hop_data)
                         if prompt in buffer:
                             break
                     else:
@@ -421,7 +457,7 @@ def traceroute_stream():
                                 "",
                             )
                             if partial:
-                                yield _sse_partial(_annotate_traceroute_line(partial))
+                                yield _sse_partial(partial)
                             line_buffer_ts = time.time()  # reset to avoid re-sending same partial
                         time.sleep(0.3)
 
@@ -433,7 +469,10 @@ def traceroute_stream():
                     )
                     if line:
                         output_lines.append(line)
-                        yield _sse_message(_annotate_traceroute_line(line))
+                        yield _sse_message(line)
+                        hop_data = _parse_traceroute_hop(line)
+                        if hop_data:
+                            yield _sse_hop(hop_data)
 
             history_result = "\n".join(output_lines)
 

--- a/neteye/troubleshoot/templates/troubleshoot/traceroute.html
+++ b/neteye/troubleshoot/templates/troubleshoot/traceroute.html
@@ -48,6 +48,7 @@
      // which prevents consecutive partials from cascading into one garbled line.
      var completedText = '';
      var partialText   = '';
+     var hopBuffer     = [];
 
      function updateOutput($output) {
          $output.text(completedText + partialText);
@@ -55,6 +56,27 @@
      }
 
      var $cancel = $('#cancel');
+
+     function renderHopTable() {
+         if (hopBuffer.length === 0) return;
+         hopBuffer.forEach(function(hop) {
+             var nodeCell = hop.hostname
+                 ? (hop.node_url ? '<a href="' + hop.node_url + '">' + hop.hostname + '</a>' : hop.hostname)
+                 : '-';
+             var ifaceCell = (hop.interface_name && hop.interface_url)
+                 ? '<a href="' + hop.interface_url + '">' + hop.interface_name + '</a>'
+                 : (hop.interface_name || '-');
+             var row = '<tr>'
+                 + '<td>' + hop.hop + '</td>'
+                 + '<td>' + hop.ip + '</td>'
+                 + '<td>' + nodeCell + '</td>'
+                 + '<td>' + ifaceCell + '</td>'
+                 + '<td>' + (hop.rtts.join('&nbsp;&nbsp;') || '-') + '</td>'
+                 + '</tr>';
+             $('#hop-tbody').append(row);
+         });
+         $('#hop-table').show();
+     }
 
      $cancel.on('click', function() {
          if (es) { es.close(); es = null; }
@@ -64,6 +86,7 @@
          if (partialText) { completedText += partialText + '\n'; partialText = ''; }
          completedText += '\n[Cancelled]';
          updateOutput($output);
+         renderHopTable();
      });
 
      $('#traceroute').on('submit', function(e) {
@@ -78,6 +101,9 @@
 
          completedText = '';
          partialText   = '';
+         hopBuffer     = [];
+         $('#hop-tbody').empty();
+         $('#hop-table').hide();
          $output.text('');
          $card.show();
          $submit.prop('disabled', true).val('Running...');
@@ -110,6 +136,11 @@
              updateOutput($output);
          });
 
+         // "hop" events: buffer structured hop data; table is rendered on [DONE] / cancel.
+         es.addEventListener('hop', function(evt) {
+             hopBuffer.push(JSON.parse(evt.data));
+         });
+
          // Default "message" events: complete lines.
          // If a partial was in progress, discard it (the complete line supersedes it).
          es.onmessage = function(evt) {
@@ -120,6 +151,7 @@
                  $submit.prop('disabled', false).val('Submit');
                  completedText += '\n[Done]';
                  updateOutput($output);
+                 renderHopTable();
                  return;
              }
              completedText += evt.data + '\n';
@@ -235,9 +267,21 @@
         <span>Result</span>
         <button type="button" class="btn btn-warning" id="cancel">Cancel</button>
     </div>
-    <div class="card-body p-0">
+    <div class="card-body">
         <pre id="result-output" class="bg-dark text-white p-3 rounded mb-0"
-             style="max-height:500px; overflow-y:auto; white-space:pre-wrap;"></pre>
+             style="max-height:400px; overflow-y:auto; white-space:pre-wrap;"></pre>
+        <table id="hop-table" class="table table-sm table-bordered mt-3 mb-0" style="display:none;">
+            <thead class="thead-light">
+                <tr>
+                    <th style="width:4em;">Hop</th>
+                    <th style="width:12em;">Address</th>
+                    <th>Node</th>
+                    <th>Interface</th>
+                    <th>RTT</th>
+                </tr>
+            </thead>
+            <tbody id="hop-tbody"></tbody>
+        </table>
     </div>
 </div>
 {% endblock main %}


### PR DESCRIPTION
## Summary

- traceroute 結果の `<pre>` ストリーミングはそのままに、完了後にホップテーブルを別表示
- サーバーが `hop` SSE イベント（JSON）を送信、JS がバッファしてテーブルを一括描画
- テーブル列: Hop / Address / Node（ノードページへリンク）/ Interface（インターフェースページへリンク）/ RTT
- ホップ行パーサー (`_parse_traceroute_hop`) が複数フォーマットに対応:
  - `IP RTTs` (NX-OS)
  - `IP (IP) RTTs` (Linux traceroute)
  - `hostname (IP) RTTs` (IOS 名前解決あり)
  - `* * *` (タイムアウト)
- RTT は `ms` / `msec` 両方対応
- DB ルックアップは Interface 優先（インターフェース名とノードリンクを正確に解決）
- `_annotate_traceroute_line()` / `_IP_RE` を削除（ホップテーブルで代替）

## Test plan

- [ ] `ENV_FOR_DYNACONF=testing python -m pytest` がグリーン
- [ ] traceroute 実行 → `<pre>` がリアルタイムストリーミングされること
- [ ] `[Done]` 後にホップテーブルが表示されること
- [ ] 登録済みノード IP → Node 列にリンク付きホスト名が表示されること
- [ ] 登録済みインターフェース IP → Interface 列にリンク付きインターフェース名が表示されること
- [ ] `* * *` ホップ → Address=`*`、Node/Interface=`-` で表示されること
- [ ] Cancel 時 → 途中までのホップがテーブル表示されること