### PR TITLE
docs: pre-fill NET_TEXTFSM with relative path in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,9 @@
 # .env is git-ignored and should never be committed.
 
 # NTC-Templates: path to the ntc-templates templates directory
-# Example: NET_TEXTFSM=/path/to/ntc-templates/ntc_templates/templates
-NET_TEXTFSM=
+# Default assumes ntc-templates was cloned alongside this repo (see README installation steps).
+# Override with an absolute path if you cloned it elsewhere.
+NET_TEXTFSM=./ntc-templates/ntc_templates/templates
 
 # Flask-Security
 NETEYE_SECRET_KEY=change-me-to-a-random-secret


### PR DESCRIPTION
## Summary

- `.env.example` の `NET_TEXTFSM` をデフォルト空から `./ntc-templates/ntc_templates/templates` に変更
- README のインストール手順通りに `git clone` した場合、追加編集なしでそのまま動くようになる
- 別の場所に clone した場合はコメントの通り絶対パスで上書きすれば対応可能

## Test plan

- [ ] `cp .env.example .env` 後、ntc-templates を `./ntc-templates` に clone した状態で `python manage.py` が起動することを確認