### PR TITLE
refactor: change command/raw_command API endpoints from GET to POST

### DIFF
--- a/neteye/api/node_namespace.py
+++ b/neteye/api/node_namespace.py
@@ -92,21 +92,26 @@ class NodeResourceFilter(AuthenticatedResource):
         return nodes
 
 
-@nodes_api.route("/<string:id>/command/<string:command>")
+command_model = nodes_api.model('Command', {
+    'command': fields.String(required=True, description='The command to execute'),
+})
+
+
+@nodes_api.route("/<string:id>/command")
 class NodeResourceCommand(AuthenticatedResource):
-    def get(self, id, command):
-        command = command.replace("+", " ")
+    @nodes_api.expect(command_model, validate=True)
+    def post(self, id):
         node = db.get_or_404(Node, id)
-        result = node.command(command, current_user.email)
+        result = node.command(api.payload["command"], current_user.email)
         return jsonify(result)
 
 
-@nodes_api.route("/<string:id>/raw_command/<string:command>")
+@nodes_api.route("/<string:id>/raw_command")
 class NodeResourceRawCommand(AuthenticatedResource):
-    def get(self, id, command):
-        command = command.replace("+", " ")
+    @nodes_api.expect(command_model, validate=True)
+    def post(self, id):
         node = db.get_or_404(Node, id)
-        result = node.raw_command(command, current_user.email)
+        result = node.raw_command(api.payload["command"], current_user.email)
         return jsonify(result)
 
 


### PR DESCRIPTION
## Summary

- Changed `/<id>/command` and `/<id>/raw_command` API endpoints from GET to POST
- Command is now passed in the JSON request body instead of the URL path
- Removed the `+`-for-space workaround that was required when encoding commands in URLs
- Added `command_model` with validation to enforce the `command` field in the request body

## Request format

```
POST /api/nodes/<id>/command
Content-Type: application/json

{"command": "show interfaces GigabitEthernet0/0"}
```

## Test plan

- [ ] `POST /api/nodes/<id>/command` with `{"command": "show version"}` returns parsed output
- [ ] `POST /api/nodes/<id>/raw_command` with `{"command": "show version"}` returns raw output
- [ ] Missing `command` field returns 400
- [ ] Web UI routes (`node/routes.py`) are unaffected