### PR TITLE
feat: encrypt SSH device credentials at rest

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,12 @@ NET_TEXTFSM=./ntc-templates/ntc_templates/templates
 NETEYE_SECRET_KEY=change-me-to-a-random-secret
 NETEYE_SECURITY_PASSWORD_SALT=change-me-to-a-random-salt
 
+# Node credential encryption: encrypts SSH username/password/enable at rest in the
+# database. Kept separate from NETEYE_SECRET_KEY — rotating SECRET_KEY (session/CSRF
+# signing) must never break decryption of already-stored device credentials.
+# Generate one with: python -c "import secrets; print(secrets.token_urlsafe(32))"
+NETEYE_NODE_CREDENTIAL_KEY=change-me-to-a-random-key
+
 # Administrator
 NETEYE_ADMIN_PASSWORD=change-me
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,9 @@ jobs:
           python-version: "3.11"
 
       - name: Install system dependencies
-        run: sudo apt-get install -y libssh2-1-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssh2-1-dev
 
       - name: Install dependencies
         run: pip install -r requirements.txt

--- a/neteye/history/routes.py
+++ b/neteye/history/routes.py
@@ -60,7 +60,7 @@ def node_history_data():
         ColumnDT(node_version.model),
         ColumnDT(node_version.os_type),
         ColumnDT(node_version.os_version),
-        ColumnDT(node_version.username, global_search=False),
+        ColumnDT(node_version.username),
         ColumnDT(node_version.operation_type),
     ]
     query = db.session.query(node_transaction.issued_at,

--- a/neteye/history/routes.py
+++ b/neteye/history/routes.py
@@ -60,7 +60,7 @@ def node_history_data():
         ColumnDT(node_version.model),
         ColumnDT(node_version.os_type),
         ColumnDT(node_version.os_version),
-        ColumnDT(node_version.username),
+        ColumnDT(node_version.username, global_search=False),
         ColumnDT(node_version.operation_type),
     ]
     query = db.session.query(node_transaction.issued_at,

--- a/neteye/lib/utils/dynaconf_validators.py
+++ b/neteye/lib/utils/dynaconf_validators.py
@@ -35,6 +35,15 @@ validators = [
         messages={"condition": "SECRET_KEY must be set to a secure random value"},
         when=Validator("ENV_FOR_DYNACONF", eq="production"),
     ),
+    # Node credentials: dedicated encryption key for SSH username/password/enable at rest.
+    # Kept separate from SECRET_KEY so rotating session/CSRF signing never breaks decryption
+    # of stored device credentials.
+    Validator(
+        "NODE_CREDENTIAL_KEY", must_exist=True,
+        condition=lambda v: v not in INSECURE_SECRET_KEYS,
+        messages={"condition": "NODE_CREDENTIAL_KEY must be set to a secure random value"},
+        when=Validator("ENV_FOR_DYNACONF", eq="production"),
+    ),
     # Netmiko
     Validator("NETMIKO_READ_TIMEOUT", is_type_of=int, gt=0, default=DEFAULTS["NETMIKO_READ_TIMEOUT"]),
     Validator("NETMIKO_CONN_TIMEOUT", is_type_of=int, gt=0, default=DEFAULTS["NETMIKO_CONN_TIMEOUT"]),

--- a/neteye/node/models.py
+++ b/neteye/node/models.py
@@ -79,7 +79,7 @@ class Node(Base):
     model = Column(String)
     os_type = Column(String)
     os_version = Column(String)
-    username = Column(StringEncryptedType(Text, _node_credential_key, AesEngine, "pkcs5"))
+    username = Column(String)
     password = Column(StringEncryptedType(Text, _node_credential_key, AesEngine, "pkcs5"))
     enable = Column(StringEncryptedType(Text, _node_credential_key, AesEngine, "pkcs5"))
     interfaces = relationship(

--- a/neteye/node/models.py
+++ b/neteye/node/models.py
@@ -7,8 +7,10 @@ import scrapli
 from netmiko.ssh_autodetect import SSHDetect
 from scrapli import Scrapli
 from sqlalchemy import (Boolean, Column, DateTime, Float, ForeignKey, Integer,
-                        String)
+                        String, Text)
 from sqlalchemy.orm import backref, relationship
+from sqlalchemy_utils import StringEncryptedType
+from sqlalchemy_utils.types.encrypted.encrypted_type import AesEngine
 
 from neteye.base.models import Base
 from neteye.extensions import connection_pool, db, ntc_template_utils, settings
@@ -54,6 +56,15 @@ SCRAPLI_DRIVERS = list(Scrapli.CORE_PLATFORM_MAP.keys()) + list(ScrapliCommunity
 NAPALM_DRIVERS = list(napalm.SUPPORTED_DRIVERS) + [NOT_SUPPORTED]
 
 
+def _node_credential_key():
+    """Return the encryption key for SSH credential columns.
+
+    Read lazily (called by StringEncryptedType on each encrypt/decrypt) so
+    Dynaconf settings are fully loaded first.
+    """
+    return settings.NODE_CREDENTIAL_KEY
+
+
 class Node(Base):
     __tablename__ = "nodes"
 
@@ -68,9 +79,9 @@ class Node(Base):
     model = Column(String)
     os_type = Column(String)
     os_version = Column(String)
-    username = Column(String)
-    password = Column(String)
-    enable = Column(String)
+    username = Column(StringEncryptedType(Text, _node_credential_key, AesEngine, "pkcs5"))
+    password = Column(StringEncryptedType(Text, _node_credential_key, AesEngine, "pkcs5"))
+    enable = Column(StringEncryptedType(Text, _node_credential_key, AesEngine, "pkcs5"))
     interfaces = relationship(
         "Interface",
         back_populates="node",

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,9 @@ SQLAlchemy>=2.0,<3.0
 Flask-SQLAlchemy>=3.1,<4.0
 SQLAlchemy-Continuum>=1.4.0
 SQLAlchemy-Utils==0.41.1
+# Required directly by SQLAlchemy-Utils EncryptedType (node credential encryption at rest);
+# also pulled in transitively via paramiko, but pin explicitly since it's now load-bearing.
+cryptography>=44.0.0
 sqlalchemy-datatables==2.0.1
 netaddr
 ssh2-python

--- a/settings.toml
+++ b/settings.toml
@@ -102,4 +102,5 @@ WTF_CSRF_ENABLED = false
 SECURITY_CSRF_PROTECT_MECHANISMS = []
 SECRET_KEY = "test-secret-key"
 SECURITY_PASSWORD_SALT = "test-salt"
+NODE_CREDENTIAL_KEY = "test-node-credential-key"
 ADMIN_PASSWORD = "Test-Admin-Pass-1!"

--- a/tests/models/test_node_credential_encryption.py
+++ b/tests/models/test_node_credential_encryption.py
@@ -21,7 +21,6 @@ class TestNodeCredentialEncryption:
 
         db.session.expire_all()
         reloaded = Node.get(node_id)
-        assert reloaded.username == "secretuser"
         assert reloaded.password == "supersecretpw"
 
         db.session.delete(reloaded)

--- a/tests/models/test_node_credential_encryption.py
+++ b/tests/models/test_node_credential_encryption.py
@@ -1,0 +1,87 @@
+import sqlite3
+
+from neteye.extensions import settings
+from neteye.node.models import Node
+from neteye.history.models import node_version
+
+
+class TestNodeCredentialEncryption:
+    def test_password_round_trips_through_orm(self, db):
+        node = Node(
+            hostname="enc-test-router",
+            ip_address="192.168.50.1",
+            port=22,
+            device_type="cisco_ios",
+            username="secretuser",
+            password="supersecretpw",
+        )
+        db.session.add(node)
+        db.session.commit()
+        node_id = node.id
+
+        db.session.expire_all()
+        reloaded = Node.get(node_id)
+        assert reloaded.username == "secretuser"
+        assert reloaded.password == "supersecretpw"
+
+        db.session.delete(reloaded)
+        db.session.commit()
+
+    def test_password_not_stored_in_plaintext_in_sqlite_file(self, db):
+        node = Node(
+            hostname="enc-test-router-2",
+            ip_address="192.168.50.2",
+            port=22,
+            device_type="cisco_ios",
+            username="plaintextcheckuser",
+            password="findme-plaintext-marker",
+        )
+        db.session.add(node)
+        db.session.commit()
+        db.session.expire_all()
+
+        db_path = settings.SQLALCHEMY_DATABASE_URI.replace("sqlite:///", "")
+        raw_conn = sqlite3.connect(db_path)
+        try:
+            cursor = raw_conn.execute(
+                "SELECT password FROM nodes WHERE hostname = ?", ("enc-test-router-2",)
+            )
+            raw_value = cursor.fetchone()[0]
+        finally:
+            raw_conn.close()
+
+        assert "findme-plaintext-marker" not in raw_value
+        assert raw_value != "findme-plaintext-marker"
+
+        node = Node.query.filter_by(hostname="enc-test-router-2").first()
+        db.session.delete(node)
+        db.session.commit()
+
+    def test_node_version_history_stores_and_returns_decrypted_password(self, db):
+        node = Node(
+            hostname="enc-test-router-3",
+            ip_address="192.168.50.3",
+            port=22,
+            device_type="cisco_ios",
+            username="histuser",
+            password="histpassword1",
+        )
+        db.session.add(node)
+        db.session.commit()
+
+        node.password = "histpassword2"
+        db.session.commit()
+
+        versions = (
+            db.session.query(node_version)
+            .filter(node_version.id == node.id)
+            .order_by(node_version.transaction_id.asc())
+            .all()
+        )
+        assert len(versions) >= 2
+        passwords = [v.password for v in versions]
+        assert "histpassword1" in passwords
+        assert "histpassword2" in passwords
+
+        db.session.delete(node)
+        db.session.commit()


### PR DESCRIPTION
## Summary

- Encrypt `Node.password` and `Node.enable` at rest using SQLAlchemy-Utils `StringEncryptedType` with AES encryption
- `Node.username` is kept as plaintext (generic values like `admin`/`cisco`, not sensitive without the password, and needed for DataTables search)
- Add dedicated `NODE_CREDENTIAL_KEY` in `.env`, separate from `SECRET_KEY` — rotating session/CSRF signing never breaks decryption of stored credentials
- SQLAlchemy-Continuum history versioning (`node_version` table) inherits the same encrypting column type transparently
- Add Dynaconf validator requiring a secure `NODE_CREDENTIAL_KEY` in production
- Pin `cryptography>=44.0.0` explicitly since it's now load-bearing for this security feature

## Setup required

Add to `.env` before deploying:
```
NETEYE_NODE_CREDENTIAL_KEY=<generate with: python -c "import secrets; print(secrets.token_urlsafe(32))">
```

## Test plan

- [ ] `test_password_round_trips_through_orm` — ORM write/read decrypts correctly
- [ ] `test_password_not_stored_in_plaintext_in_sqlite_file` — raw SQLite value is ciphertext
- [ ] `test_node_version_history_stores_and_returns_decrypted_password` — Continuum history also encrypts/decrypts transparently
- [ ] All 92 existing tests pass with no regressions